### PR TITLE
Introduce event loop infrastructure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,3 +11,30 @@ AllowShortLoopsOnASingleLine: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 BinPackArguments: false
 BinPackParameters: false
+BreakAfterReturnType: Automatic
+PenaltyReturnTypeOnItsOwnLine: 1000
+
+AlwaysBreakTemplateDeclarations: Yes
+
+InsertNewlineAtEOF: true
+
+IncludeIsMainRegex: "(_test)?$"
+IncludeBlocks: Regroup
+SortIncludes: true
+IncludeCategories:
+  - Regex:           '^<[a-z]+\.h>'       # <unistd.h>
+    Priority:        1
+  - Regex:           '^<[a-z]+/.*\.h>'    # <sys/event.h>
+    Priority:        1
+  - Regex:           '^<c(string|std).*>' # <cstring>
+    Priority:        2
+  - Regex:           '^<[^/]*>'           # <other>
+    Priority:        3
+  - Regex:           '^<.*/'              # <a/other>
+    Priority:        3
+  - Regex:           '^"gtest/.*"'        # "gtest/gtest.h"
+    Priority:        5
+  - Regex:           '^".*/'              # "b/project"
+    Priority:        4
+  - Regex:           '^".*"'              # "project"
+    Priority:        4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+Checks: >
+  -*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  google-*,
+  misc-*,
+  performance-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -readability-identifier-length
+
+HeaderFilterRegex: '.*'
+WarningsAsErrors: "*"
+
+CheckOptions:
+ - { key: readability-identifier-naming.NamespaceCase,         value: lower_case }
+ - { key: readability-identifier-naming.ClassCase,             value: CamelCase  }
+ - { key: readability-identifier-naming.StructCase,            value: CamelCase  }
+ - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase  }
+ - { key: readability-identifier-naming.FunctionCase,          value: lower_case }
+ - { key: readability-identifier-naming.VariableCase,          value: lower_case }
+ - { key: readability-identifier-naming.PrivateMemberSuffix,   value: _          }
+ - { key: readability-identifier-naming.ProtectedMemberSuffix, value: _          }
+ - { key: readability-identifier-naming.MacroDefinitionCase,   value: UPPER_CASE }
+ - { key: readability-identifier-naming.EnumConstantCase,      value: CamelCase  }
+ - { key: readability-identifier-naming.EnumConstantPrefix,    value: k          }
+ - { key: readability-identifier-naming.GlobalConstantCase,    value: lower_case }
+ - { key: readability-identifier-naming.GlobalConstantPrefix,  value: k_         }
+ - { key: readability-identifier-naming.MemberConstantCase,    value: lower_case }
+ - { key: readability-identifier-naming.MemberConstantPrefix,  value: k_         }
+ - { key: readability-identifier-naming.StaticConstantCase,    value: lower_case }
+ - { key: readability-identifier-naming.StaticConstantPrefix,  value: k_         }
+
+ - { key: bugprone-unused-return-value.CheckedFunctions, value:   '^.*$' }
+ - { key: bugprone-unused-return-value.CheckedReturnTypes, value: '^.*$' }
+ - { key: bugprone-unused-return-value.AllowCastToVoid,    value:  true}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,60 @@
-name: build
+name: Legatus CI
 
 on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
 
 jobs:
+  format:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Setup environment
+      run: ./tools/install-deps.sh
+
+    - name: Run clang-format
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_COMMIT=${{ github.event.pull_request.base.sha }}
+            THIS_COMMIT=${{ github.event.pull_request.head.sha }}
+            git clang-format --diff $BASE_COMMIT $THIS_COMMIT
+        else
+            git clang-format --diff HEAD^
+        fi
+
+  lint:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+         submodules: recursive
+
+    - name: Setup environment
+      run: ./tools/install-deps.sh
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build
+
+    - name: Run clang-tidy
+      run: cmake --build ${{github.workspace}}/build -t lint
+
   build:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ macos-latest ]
+        build_type:
+          - -DENABLE_MSAN=ON
+          - -DENABLE_UBSAN=ON
+          - -DCMAKE_BUILD_TYPE=Release
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +62,7 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build
+      run: cmake -B ${{github.workspace}}/build ${{ matrix.build_options }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.swp
+*.swp
 
-.idea/
-build/
-cmake-build-debug/
-cmake-build-release/
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,59 @@
 cmake_minimum_required(VERSION 3.20)
 project(legatus CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 enable_testing()
 
+
 # Directories
 set(LEGATUS_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
+set(LEGATUS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(LEGATUS_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test)
 
 set(LEGATUS_THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
 set(LEGATUS_GOOGLETEST_DIR ${LEGATUS_THIRD_PARTY_DIR}/googletest)
 
+add_compile_options(
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Werror
+)
+
+option(ENABLE_MSAN "Enable Memory Sanitizer" OFF)
+option(ENABLE_USAN "Enable Undefined Behavior Sanitizer" OFF)
+
+if(ENABLE_MSAN)
+    if(APPLE)
+        add_compile_options(
+            -fsanitize=address
+            -fno-omit-frame-pointer
+            -g
+        )
+        add_link_options(-fsanitize=address)
+    else()
+        add_compile_options(
+            -fsanitize=memory
+            -fno-omit-frame-pointer
+            -g
+        )
+        add_link_options(-fsanitize=memory)
+    endif()
+endif()
+
+if(ENABLE_UBSAN)
+    add_compile_options(
+        -fsanitize=undefined
+        -g
+    )
+    add_link_options(-fsanitize=undefined)
+endif()
+
 # Dependencies
 add_subdirectory(${LEGATUS_GOOGLETEST_DIR} EXCLUDE_FROM_ALL)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Project version
 file(READ VERSION LEGATUS_PROJECT_VERSION)
@@ -32,20 +72,23 @@ if (NOT ${LEGATUS_GIT_COMMIT_RESULT} STREQUAL 0)
 endif()
 
 message("legatus version information: " ${LEGATUS_PROJECT_VERSION} " - " ${LEGATUS_GIT_COMMIT_HASH})
-configure_file(${LEGATUS_SRC_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/gen/version.h @ONLY)
+configure_file(${LEGATUS_SRC_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/gen/version.cpp @ONLY)
 
 # Source files
 set(LEGATUS_SRC_LIST
     ${LEGATUS_SRC_DIR}/legatus.cpp
+    ${LEGATUS_SRC_DIR}/io/event.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/gen/version.cpp
 )
 
 # Test files
 set(LEGATUS_TEST_LIST
     ${LEGATUS_TEST_DIR}/legatus_test.cpp
+    ${LEGATUS_TEST_DIR}/io/event_test.cpp
 )
 
 add_library(legatus-lib ${LEGATUS_SRC_LIST})
-target_include_directories(legatus-lib PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_include_directories(legatus-lib PUBLIC ${LEGATUS_INCLUDE_DIR} ${LEGATUS_SRC_DIR})
 set_target_properties(legatus-lib PROPERTIES OUTPUT_NAME legatus)
 
 add_executable(legatus-tests ${LEGATUS_TEST_LIST})
@@ -53,3 +96,8 @@ target_include_directories(legatus-tests PRIVATE ${LEGATUS_SRC_DIR})
 target_link_libraries(legatus-tests legatus-lib gtest_main)
 
 add_test(unit-tests legatus-tests)
+
+add_custom_target(lint
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/run-clang-tidy.py -p=${CMAKE_BINARY_DIR} -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
+  COMMENT "Running clang-tidy..."
+)

--- a/include/legatus/io/event.h
+++ b/include/legatus/io/event.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <sys/event.h>
+
+#include <cstdint>
+
+#include <functional>
+#include <unordered_map>
+
+namespace legatus::io {
+
+using TimerCallback = std::function<void(uint64_t, int64_t)>;
+
+class EventLoop {
+  public:
+    EventLoop();
+    EventLoop(const EventLoop&) = delete;
+    EventLoop& operator=(const EventLoop&) = delete;
+    EventLoop(EventLoop&&) = delete;
+    EventLoop& operator=(EventLoop&&) = delete;
+
+    ~EventLoop();
+
+    void shutdown() const;
+
+    int register_timer(uint64_t id, uint64_t timeout, bool periodic, const TimerCallback& cb);
+
+    void run();
+
+  private:
+    static constexpr uint64_t k_shutdown_event_id = 19;
+
+    int kq_;
+    bool done_ = false;
+    std::unordered_map<uint64_t, TimerCallback> timers_;
+
+    void do_shutdown();
+};
+
+} // namespace legatus::io

--- a/src/io/event.cpp
+++ b/src/io/event.cpp
@@ -1,0 +1,93 @@
+#include "legatus/io/event.h"
+
+#include <sys/event.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+
+#include <stdexcept>
+
+namespace legatus::io {
+
+EventLoop::EventLoop() : kq_(kqueue()) {
+    if (kq_ == -1) {
+        throw std::runtime_error("failed to initialize kqueue");
+    }
+
+    // Register shutdown handler
+    struct kevent ev{};
+    EV_SET(&ev, k_shutdown_event_id, EVFILT_USER, EV_ADD, 0, 0, nullptr);
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        throw std::runtime_error("failed to register shutdown handler");
+    }
+}
+
+EventLoop::~EventLoop() {
+    const int ret = close(kq_);
+    if (ret == -1) {
+        perror("failed to close kqueue file descriptor");
+    }
+}
+
+int EventLoop::register_timer(uint64_t id,
+                              uint64_t timeout,
+                              bool periodic,
+                              const TimerCallback& cb) {
+    struct kevent ev{};
+    const uint16_t oneshot = periodic ? 0 : EV_ONESHOT;
+
+    EV_SET(&ev, id, EVFILT_TIMER, EV_ADD | oneshot, NOTE_NSECONDS, timeout, nullptr);
+    timers_[id] = cb;
+
+    return kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+}
+
+void EventLoop::shutdown() const {
+    struct kevent ev{};
+    EV_SET(&ev, k_shutdown_event_id, EVFILT_USER, 0, NOTE_TRIGGER, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to schedule shutdown event");
+    }
+}
+
+void EventLoop::run() {
+    struct kevent ev{};
+
+    while (!done_) {
+        const int ret = kevent(kq_, nullptr, 0, &ev, 1, nullptr);
+        if (ret == -1) {
+            perror("failed to wait for events");
+            continue;
+        }
+
+        const uint64_t id = ev.ident;
+
+        switch (ev.filter) {
+        case EVFILT_USER: {
+            if (id == k_shutdown_event_id) {
+                done_ = true;
+            }
+            break;
+        }
+
+        case EVFILT_TIMER: {
+            const auto& cb = timers_[id];
+            if ((ev.flags & EV_ERROR) != 0) {
+                cb(ev.ident, ev.data);
+            } else {
+                cb(ev.ident, 0);
+            }
+            break;
+        }
+
+        default:
+            perror("unknown event type");
+        }
+    }
+}
+
+} // namespace legatus::io

--- a/src/legatus.cpp
+++ b/src/legatus.cpp
@@ -1,5 +1,7 @@
 #include "legatus.h"
 
+#include <string>
+
 #include "version.h"
 
 namespace legatus {
@@ -9,11 +11,11 @@ std::string Legatus::get_version() {
 }
 
 void Legatus::add(int a, int b) {
-    result = a + b;
+    result_ = a + b;
 }
 
 int Legatus::get_result() const {
-    return result;
+    return result_;
 }
 
 } // namespace legatus

--- a/src/legatus.h
+++ b/src/legatus.h
@@ -1,5 +1,4 @@
-#ifndef LEGATUS_LEGATUS_H_
-#define LEGATUS_LEGATUS_H_
+#pragma once
 
 #include <string>
 
@@ -13,9 +12,7 @@ class Legatus {
     int get_result() const;
 
   private:
-    int result;
+    int result_;
 };
 
 } // namespace legatus
-
-#endif // LEGATUS_LEGATUS_H_

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,12 +1,15 @@
-#ifndef LEGATUS_VERSION_H_
-#define LEGATUS_VERSION_H_
+#include "version.h"
+
+#include <string>
 
 namespace legatus {
 
 namespace {
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #cmakedefine LEGATUS_PROJECT_VERSION "@LEGATUS_PROJECT_VERSION@"
 #cmakedefine LEGATUS_GIT_COMMIT_HASH "@LEGATUS_GIT_COMMIT_HASH@"
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 } // namespace
 
@@ -19,5 +22,3 @@ std::string git_commit_hash() {
 }
 
 } // namespace legatus
-
-#endif // LEGATUS_VERSION_H_

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+namespace legatus {
+
+std::string version();
+
+std::string git_commit_hash();
+
+} // namespace legatus

--- a/test/io/event_test.cpp
+++ b/test/io/event_test.cpp
@@ -1,0 +1,95 @@
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+#include "legatus/io/event.h"
+
+#include <cstdint>
+
+#include "gtest/gtest.h"
+
+namespace legatus::io {
+TEST(EventLoopTest, TimerOneshot) {
+    legatus::io::EventLoop ev_loop;
+    int timer_id = 1;
+    const uint64_t delay = 5e8;
+    bool called = false;
+
+    const TimerCallback cb = [&](uint64_t id, int64_t err) {
+        ASSERT_EQ(timer_id, id);
+        ASSERT_EQ(0, err);
+
+        called = true;
+
+        ev_loop.shutdown();
+    };
+
+    const int res = ev_loop.register_timer(timer_id, delay, false /* periodic */, cb);
+    ASSERT_EQ(0, res);
+
+    ev_loop.run();
+
+    ASSERT_EQ(true, called);
+}
+
+TEST(EventLoopTest, TimerPeriodic) {
+    legatus::io::EventLoop ev_loop;
+    int timer_id = 1;
+    const uint64_t delay = 5e8;
+    int counter = 0;
+    int counter_max = 4;
+
+    const TimerCallback cb = [&](uint64_t id, int64_t err) {
+        ASSERT_EQ(timer_id, id);
+        ASSERT_EQ(0, err);
+
+        ++counter;
+
+        if (counter == counter_max) {
+            ev_loop.shutdown();
+        }
+    };
+
+    const int res = ev_loop.register_timer(timer_id, delay, true /* periodic */, cb);
+    ASSERT_EQ(0, res);
+
+    ev_loop.run();
+
+    ASSERT_EQ(counter_max, counter);
+}
+
+TEST(EventLoopTest, TimerUpdate) {
+    legatus::io::EventLoop ev_loop;
+    int timer_id = 1;
+    const uint64_t delay = 5e8;
+    int counter = 0;
+    int counter_max = 4;
+    bool called = false;
+
+    const TimerCallback cb_oneshot = [&](uint64_t id, int64_t err) {
+        ASSERT_EQ(timer_id, id);
+        ASSERT_EQ(0, err);
+
+        called = true;
+
+        ev_loop.shutdown();
+    };
+
+    const TimerCallback cb_periodic = [&](uint64_t id, int64_t err) {
+        ASSERT_EQ(timer_id, id);
+        ASSERT_EQ(0, err);
+        ++counter;
+        if (counter == counter_max) {
+            const int res = ev_loop.register_timer(id, delay, false /* periodic */, cb_oneshot);
+            ASSERT_EQ(0, res);
+        }
+    };
+
+    const int res = ev_loop.register_timer(timer_id, delay, true /* periodic */, cb_periodic);
+    ASSERT_EQ(0, res);
+
+    ev_loop.run();
+
+    ASSERT_EQ(counter_max, counter);
+}
+
+} // namespace legatus::io
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/test/legatus_test.cpp
+++ b/test/legatus_test.cpp
@@ -4,12 +4,12 @@
 
 class LegatusTest : public ::testing::Test {
   protected:
-    legatus::Legatus legatus{};
+    legatus::Legatus legatus_{};
 };
 
 TEST_F(LegatusTest, Adder) {
-    legatus.add(1, 2);
-    ASSERT_EQ(legatus.get_result(), 3);
+    legatus_.add(1, 2);
+    ASSERT_EQ(legatus_.get_result(), 3);
 }
 
 TEST_F(LegatusTest, Version) {

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SRC_DIR=$(dirname ${BASH_SOURCE[0]})
+OS=$(uname)
+if [ $OS = "Darwin" ]; then
+    echo "Running on macOS"
+    . $SRC_DIR/setup-darwin.sh
+else
+    echo "Unsupported OS: $OS"
+    exit 1
+fi
+
+install-clang-format
+install-clang-tidy

--- a/tools/run-clang-tidy.py
+++ b/tools/run-clang-tidy.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+#
+# ===- run-clang-tidy.py - Parallel clang-tidy runner --------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+import glob
+import json
+import multiprocessing
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+from types import ModuleType
+from typing import Any, Awaitable, Callable, List, Optional, TypeVar
+
+
+yaml: Optional[ModuleType] = None
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to a bool following LLVM's CLI argument parsing."""
+
+    val = val.lower()
+    if val in ["", "true", "1"]:
+        return True
+    elif val in ["false", "0"]:
+        return False
+
+    # Return ArgumentTypeError so that argparse does not substitute its own error message
+    raise argparse.ArgumentTypeError(
+        f"'{val}' is invalid value for boolean argument! Try 0 or 1."
+    )
+
+
+def find_compilation_database(path: str) -> str:
+    """Adjusts the directory until a compilation database is found."""
+    result = os.path.realpath("./")
+    while not os.path.isfile(os.path.join(result, path)):
+        parent = os.path.dirname(result)
+        if result == parent:
+            print("Error: could not find compilation database.")
+            sys.exit(1)
+        result = parent
+    return result
+
+
+def get_tidy_invocation(
+    f: str,
+    clang_tidy_binary: str,
+    checks: str,
+    tmpdir: Optional[str],
+    build_path: str,
+    header_filter: Optional[str],
+    allow_enabling_alpha_checkers: bool,
+    extra_arg: List[str],
+    extra_arg_before: List[str],
+    quiet: bool,
+    config_file_path: str,
+    config: str,
+    line_filter: Optional[str],
+    use_color: bool,
+    plugins: List[str],
+    warnings_as_errors: Optional[str],
+    exclude_header_filter: Optional[str],
+    allow_no_checks: bool,
+) -> List[str]:
+    """Gets a command line for clang-tidy."""
+    start = [clang_tidy_binary]
+    if allow_enabling_alpha_checkers:
+        start.append("-allow-enabling-analyzer-alpha-checkers")
+    if exclude_header_filter is not None:
+        start.append(f"--exclude-header-filter={exclude_header_filter}")
+    if header_filter is not None:
+        start.append(f"-header-filter={header_filter}")
+    if line_filter is not None:
+        start.append(f"-line-filter={line_filter}")
+    if use_color is not None:
+        if use_color:
+            start.append("--use-color")
+        else:
+            start.append("--use-color=false")
+    if checks:
+        start.append(f"-checks={checks}")
+    if tmpdir is not None:
+        start.append("-export-fixes")
+        # Get a temporary file. We immediately close the handle so clang-tidy can
+        # overwrite it.
+        (handle, name) = tempfile.mkstemp(suffix=".yaml", dir=tmpdir)
+        os.close(handle)
+        start.append(name)
+    for arg in extra_arg:
+        start.append(f"-extra-arg={arg}")
+    for arg in extra_arg_before:
+        start.append(f"-extra-arg-before={arg}")
+    start.append(f"-p={build_path}")
+    if quiet:
+        start.append("-quiet")
+    if config_file_path:
+        start.append(f"--config-file={config_file_path}")
+    elif config:
+        start.append(f"-config={config}")
+    for plugin in plugins:
+        start.append(f"-load={plugin}")
+    if warnings_as_errors:
+        start.append(f"--warnings-as-errors={warnings_as_errors}")
+    if allow_no_checks:
+        start.append("--allow-no-checks")
+    start.append(f)
+    return start
+
+
+def merge_replacement_files(tmpdir: str, mergefile: str) -> None:
+    """Merge all replacement files in a directory into a single file"""
+    assert yaml
+    # The fixes suggested by clang-tidy >= 4.0.0 are given under
+    # the top level key 'Diagnostics' in the output yaml files
+    mergekey = "Diagnostics"
+    merged = []
+    for replacefile in glob.iglob(os.path.join(tmpdir, "*.yaml")):
+        content = yaml.safe_load(open(replacefile, "r"))
+        if not content:
+            continue  # Skip empty files.
+        merged.extend(content.get(mergekey, []))
+
+    if merged:
+        # MainSourceFile: The key is required by the definition inside
+        # include/clang/Tooling/ReplacementsYaml.h, but the value
+        # is actually never used inside clang-apply-replacements,
+        # so we set it to '' here.
+        output = {"MainSourceFile": "", mergekey: merged}
+        with open(mergefile, "w") as out:
+            yaml.safe_dump(output, out)
+    else:
+        # Empty the file:
+        open(mergefile, "w").close()
+
+
+def find_binary(arg: str, name: str, build_path: str) -> str:
+    """Get the path for a binary or exit"""
+    if arg:
+        if shutil.which(arg):
+            return arg
+        else:
+            raise SystemExit(
+                f"error: passed binary '{arg}' was not found or is not executable"
+            )
+
+    built_path = os.path.join(build_path, "bin", name)
+    binary = shutil.which(name) or shutil.which(built_path)
+    if binary:
+        return binary
+    else:
+        raise SystemExit(f"error: failed to find {name} in $PATH or at {built_path}")
+
+
+def apply_fixes(
+    args: argparse.Namespace, clang_apply_replacements_binary: str, tmpdir: str
+) -> None:
+    """Calls clang-apply-fixes on a given directory."""
+    invocation = [clang_apply_replacements_binary]
+    invocation.append("-ignore-insert-conflict")
+    if args.format:
+        invocation.append("-format")
+    if args.style:
+        invocation.append(f"-style={args.style}")
+    invocation.append(tmpdir)
+    subprocess.call(invocation)
+
+
+# FIXME Python 3.12: This can be simplified out with run_with_semaphore[T](...).
+T = TypeVar("T")
+
+
+async def run_with_semaphore(
+    semaphore: asyncio.Semaphore,
+    f: Callable[..., Awaitable[T]],
+    *args: Any,
+    **kwargs: Any,
+) -> T:
+    async with semaphore:
+        return await f(*args, **kwargs)
+
+
+@dataclass
+class ClangTidyResult:
+    filename: str
+    invocation: List[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed: float
+
+
+async def run_tidy(
+    args: argparse.Namespace,
+    name: str,
+    clang_tidy_binary: str,
+    tmpdir: str,
+    build_path: str,
+) -> ClangTidyResult:
+    """
+    Runs clang-tidy on a single file and returns the result.
+    """
+    invocation = get_tidy_invocation(
+        name,
+        clang_tidy_binary,
+        args.checks,
+        tmpdir,
+        build_path,
+        args.header_filter,
+        args.allow_enabling_alpha_checkers,
+        args.extra_arg,
+        args.extra_arg_before,
+        args.quiet,
+        args.config_file,
+        args.config,
+        args.line_filter,
+        args.use_color,
+        args.plugins,
+        args.warnings_as_errors,
+        args.exclude_header_filter,
+        args.allow_no_checks,
+    )
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        start = time.time()
+        stdout, stderr = await process.communicate()
+        end = time.time()
+    except asyncio.CancelledError:
+        process.terminate()
+        await process.wait()
+        raise
+
+    assert process.returncode is not None
+    return ClangTidyResult(
+        name,
+        invocation,
+        process.returncode,
+        stdout.decode("UTF-8"),
+        stderr.decode("UTF-8"),
+        end - start,
+    )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Runs clang-tidy over all files "
+        "in a compilation database. Requires "
+        "clang-tidy and clang-apply-replacements in "
+        "$PATH or in your build directory."
+    )
+    parser.add_argument(
+        "-allow-enabling-alpha-checkers",
+        action="store_true",
+        help="Allow alpha checkers from clang-analyzer.",
+    )
+    parser.add_argument(
+        "-clang-tidy-binary", metavar="PATH", help="Path to clang-tidy binary."
+    )
+    parser.add_argument(
+        "-clang-apply-replacements-binary",
+        metavar="PATH",
+        help="Path to clang-apply-replacements binary.",
+    )
+    parser.add_argument(
+        "-checks",
+        default=None,
+        help="Checks filter, when not specified, use clang-tidy default.",
+    )
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument(
+        "-config",
+        default=None,
+        help="Specifies a configuration in YAML/JSON format: "
+        "  -config=\"{Checks: '*', "
+        '                       CheckOptions: {x: y}}" '
+        "When the value is empty, clang-tidy will "
+        "attempt to find a file named .clang-tidy for "
+        "each source file in its parent directories.",
+    )
+    config_group.add_argument(
+        "-config-file",
+        default=None,
+        help="Specify the path of .clang-tidy or custom config "
+        "file: e.g. -config-file=/some/path/myTidyConfigFile. "
+        "This option internally works exactly the same way as "
+        "-config option after reading specified config file. "
+        "Use either -config-file or -config, not both.",
+    )
+    parser.add_argument(
+        "-exclude-header-filter",
+        default=None,
+        help="Regular expression matching the names of the "
+        "headers to exclude diagnostics from. Diagnostics from "
+        "the main file of each translation unit are always "
+        "displayed.",
+    )
+    parser.add_argument(
+        "-header-filter",
+        default=None,
+        help="Regular expression matching the names of the "
+        "headers to output diagnostics from. Diagnostics from "
+        "the main file of each translation unit are always "
+        "displayed.",
+    )
+    parser.add_argument(
+        "-source-filter",
+        default=None,
+        help="Regular expression matching the names of the "
+        "source files from compilation database to output "
+        "diagnostics from.",
+    )
+    parser.add_argument(
+        "-line-filter",
+        default=None,
+        help="List of files with line ranges to filter the warnings.",
+    )
+    if yaml:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="file_or_directory",
+            dest="export_fixes",
+            help="A directory or a yaml file to store suggested fixes in, "
+            "which can be applied with clang-apply-replacements. If the "
+            "parameter is a directory, the fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
+        )
+    else:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="directory",
+            dest="export_fixes",
+            help="A directory to store suggested fixes in, which can be applied "
+            "with clang-apply-replacements. The fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
+        )
+    parser.add_argument(
+        "-j",
+        type=int,
+        default=0,
+        help="Number of tidy instances to be run in parallel.",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        default=[".*"],
+        help="Files to be processed (regex on path).",
+    )
+    parser.add_argument("-fix", action="store_true", help="apply fix-its.")
+    parser.add_argument(
+        "-format", action="store_true", help="Reformat code after applying fixes."
+    )
+    parser.add_argument(
+        "-style",
+        default="file",
+        help="The style of reformat code after applying fixes.",
+    )
+    parser.add_argument(
+        "-use-color",
+        type=strtobool,
+        nargs="?",
+        const=True,
+        help="Use colors in diagnostics, overriding clang-tidy's"
+        " default behavior. This option overrides the 'UseColor"
+        "' option in .clang-tidy file, if any.",
+    )
+    parser.add_argument(
+        "-p", dest="build_path", help="Path used to read a compile command database."
+    )
+    parser.add_argument(
+        "-extra-arg",
+        dest="extra_arg",
+        action="append",
+        default=[],
+        help="Additional argument to append to the compiler command line.",
+    )
+    parser.add_argument(
+        "-extra-arg-before",
+        dest="extra_arg_before",
+        action="append",
+        default=[],
+        help="Additional argument to prepend to the compiler command line.",
+    )
+    parser.add_argument(
+        "-quiet", action="store_true", help="Run clang-tidy in quiet mode."
+    )
+    parser.add_argument(
+        "-load",
+        dest="plugins",
+        action="append",
+        default=[],
+        help="Load the specified plugin in clang-tidy.",
+    )
+    parser.add_argument(
+        "-warnings-as-errors",
+        default=None,
+        help="Upgrades warnings to errors. Same format as '-checks'.",
+    )
+    parser.add_argument(
+        "-allow-no-checks",
+        action="store_true",
+        help="Allow empty enabled checks.",
+    )
+    args = parser.parse_args()
+
+    db_path = "compile_commands.json"
+
+    if args.build_path is not None:
+        build_path = args.build_path
+    else:
+        # Find our database
+        build_path = find_compilation_database(db_path)
+
+    clang_tidy_binary = find_binary(args.clang_tidy_binary, "clang-tidy", build_path)
+
+    if args.fix:
+        clang_apply_replacements_binary = find_binary(
+            args.clang_apply_replacements_binary, "clang-apply-replacements", build_path
+        )
+
+    combine_fixes = False
+    export_fixes_dir: Optional[str] = None
+    delete_fixes_dir = False
+    if args.export_fixes is not None:
+        # if a directory is given, create it if it does not exist
+        if args.export_fixes.endswith(os.path.sep) and not os.path.isdir(
+            args.export_fixes
+        ):
+            os.makedirs(args.export_fixes)
+
+        if not os.path.isdir(args.export_fixes):
+            if not yaml:
+                raise RuntimeError(
+                    "Cannot combine fixes in one yaml file. Either install PyYAML or specify an output directory."
+                )
+
+            combine_fixes = True
+
+        if os.path.isdir(args.export_fixes):
+            export_fixes_dir = args.export_fixes
+
+    if export_fixes_dir is None and (args.fix or combine_fixes):
+        export_fixes_dir = tempfile.mkdtemp()
+        delete_fixes_dir = True
+
+    try:
+        invocation = get_tidy_invocation(
+            "",
+            clang_tidy_binary,
+            args.checks,
+            None,
+            build_path,
+            args.header_filter,
+            args.allow_enabling_alpha_checkers,
+            args.extra_arg,
+            args.extra_arg_before,
+            args.quiet,
+            args.config_file,
+            args.config,
+            args.line_filter,
+            args.use_color,
+            args.plugins,
+            args.warnings_as_errors,
+            args.exclude_header_filter,
+            args.allow_no_checks,
+        )
+        invocation.append("-list-checks")
+        invocation.append("-")
+        # Even with -quiet we still want to check if we can call clang-tidy.
+        subprocess.check_call(
+            invocation, stdout=subprocess.DEVNULL if args.quiet else None
+        )
+    except:
+        print("Unable to run clang-tidy.", file=sys.stderr)
+        sys.exit(1)
+
+    # Load the database and extract all files.
+    with open(os.path.join(build_path, db_path)) as f:
+        database = json.load(f)
+    files = {os.path.abspath(os.path.join(e["directory"], e["file"])) for e in database}
+    number_files_in_database = len(files)
+
+    # Filter source files from compilation database.
+    if args.source_filter:
+        try:
+            source_filter_re = re.compile(args.source_filter)
+        except:
+            print(
+                "Error: unable to compile regex from arg -source-filter:",
+                file=sys.stderr,
+            )
+            traceback.print_exc()
+            sys.exit(1)
+        files = {f for f in files if source_filter_re.match(f)}
+
+    max_task = args.j
+    if max_task == 0:
+        max_task = multiprocessing.cpu_count()
+
+    # Build up a big regexy filter from all command line arguments.
+    file_name_re = re.compile("|".join(args.files))
+    files = {f for f in files if file_name_re.search(f)}
+
+    print(
+        "Running clang-tidy for",
+        len(files),
+        "files out of",
+        number_files_in_database,
+        "in compilation database ...",
+    )
+
+    returncode = 0
+    semaphore = asyncio.Semaphore(max_task)
+    tasks = [
+        asyncio.create_task(
+            run_with_semaphore(
+                semaphore,
+                run_tidy,
+                args,
+                f,
+                clang_tidy_binary,
+                export_fixes_dir,
+                build_path,
+            )
+        )
+        for f in files
+    ]
+
+    try:
+        for i, coro in enumerate(asyncio.as_completed(tasks)):
+            result = await coro
+            if result.returncode != 0:
+                returncode = 1
+                if result.returncode < 0:
+                    result.stderr += f"{result.filename}: terminated by signal {-result.returncode}\n"
+            progress = f"[{i + 1: >{len(f'{len(files)}')}}/{len(files)}]"
+            runtime = f"[{result.elapsed:.1f}s]"
+            print(f"{progress}{runtime} {' '.join(result.invocation)}")
+            if result.stdout:
+                print(result.stdout, end=("" if result.stderr else "\n"))
+            if result.stderr:
+                print(result.stderr)
+    except asyncio.CancelledError:
+        print("\nCtrl-C detected, goodbye.")
+        for task in tasks:
+            task.cancel()
+        if delete_fixes_dir:
+            assert export_fixes_dir
+            shutil.rmtree(export_fixes_dir)
+        return
+
+    if combine_fixes:
+        print(f"Writing fixes to {args.export_fixes} ...")
+        try:
+            assert export_fixes_dir
+            merge_replacement_files(export_fixes_dir, args.export_fixes)
+        except:
+            print("Error exporting fixes.\n", file=sys.stderr)
+            traceback.print_exc()
+            returncode = 1
+
+    if args.fix:
+        print("Applying fixes ...")
+        try:
+            assert export_fixes_dir
+            apply_fixes(args, clang_apply_replacements_binary, export_fixes_dir)
+        except:
+            print("Error applying fixes.\n", file=sys.stderr)
+            traceback.print_exc()
+            returncode = 1
+
+    if delete_fixes_dir:
+        assert export_fixes_dir
+        shutil.rmtree(export_fixes_dir)
+    sys.exit(returncode)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/tools/setup-darwin.sh
+++ b/tools/setup-darwin.sh
@@ -1,0 +1,10 @@
+function install-clang-format() {
+    brew update
+    brew install clang-format@19
+}
+
+function install-clang-tidy() {
+    brew update
+    brew install llvm@19
+    sudo ln -s "$(brew --prefix llvm@19)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+}


### PR DESCRIPTION
Implements a simple event loop that handles timer events. The event loop is build using the kqueue facility on *BSD/macOS and at the moment is the only suppored platform.

A big portion of this patch sets up the necessary infrastructure to format and lint the code, and run automated builds with various sanitizers.