### PR TITLE
Upgrade clang to 19.1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Setup environment
+      run: ./tools/install-deps.sh
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build ${{ matrix.build_options }}
+      run: cmake -B ${{github.workspace}}/build ${{ matrix.build_options }} -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -10,5 +10,6 @@ else
     exit 1
 fi
 
+install-clang
 install-clang-format
 install-clang-tidy

--- a/tools/setup-darwin.sh
+++ b/tools/setup-darwin.sh
@@ -1,3 +1,9 @@
+function install-clang() {
+    brew update
+    brew install llvm@19
+    sudo ln -s "$(brew --prefix llvm@19)/bin/clang++" "/usr/local/bin/clang++"
+}
+
 function install-clang-format() {
     brew update
     brew install clang-format@19
@@ -8,3 +14,4 @@ function install-clang-tidy() {
     brew install llvm@19
     sudo ln -s "$(brew --prefix llvm@19)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 }
+


### PR DESCRIPTION
Use homebrew to install the required version. This is newer than Apple's default v15.0.0 from 2020.