### PR TITLE
Implement Status type

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,7 @@ IncludeCategories:
     Priority:        1
   - Regex:           '^<[a-z]+/.*\.h>'    # <sys/event.h>
     Priority:        1
-  - Regex:           '^<c(string|std).*>' # <cstring>
+  - Regex:           '^<c(errno|string|std).*>' # <cstring>
     Priority:        2
   - Regex:           '^<[^/]*>'           # <other>
     Priority:        3

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,8 +22,7 @@ CheckOptions:
  - { key: readability-identifier-naming.PrivateMemberSuffix,   value: _          }
  - { key: readability-identifier-naming.ProtectedMemberSuffix, value: _          }
  - { key: readability-identifier-naming.MacroDefinitionCase,   value: UPPER_CASE }
- - { key: readability-identifier-naming.EnumConstantCase,      value: CamelCase  }
- - { key: readability-identifier-naming.EnumConstantPrefix,    value: k          }
+ - { key: readability-identifier-naming.EnumConstantCase,      value: UPPER_CASE }
  - { key: readability-identifier-naming.GlobalConstantCase,    value: lower_case }
  - { key: readability-identifier-naming.GlobalConstantPrefix,  value: k_         }
  - { key: readability-identifier-naming.MemberConstantCase,    value: lower_case }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(LEGATUS_SRC_LIST
 # Test files
 set(LEGATUS_TEST_LIST
     ${LEGATUS_TEST_DIR}/legatus_test.cpp
+    ${LEGATUS_TEST_DIR}/status_test.cpp
     ${LEGATUS_TEST_DIR}/io/event_test.cpp
 )
 

--- a/include/legatus/io/event.h
+++ b/include/legatus/io/event.h
@@ -7,6 +7,8 @@
 #include <functional>
 #include <unordered_map>
 
+#include "legatus/status.h"
+
 namespace legatus::io {
 
 using TimerCallback = std::function<void(uint64_t, int64_t)>;
@@ -21,9 +23,12 @@ class EventLoop {
 
     ~EventLoop();
 
-    void shutdown() const;
+    Status<None, int> shutdown() const;
 
-    int register_timer(uint64_t id, uint64_t timeout, bool periodic, const TimerCallback& cb);
+    Status<None, int> register_timer(uint64_t id,
+                                     uint64_t timeout,
+                                     bool periodic,
+                                     const TimerCallback& cb);
 
     void run();
 

--- a/include/legatus/status.h
+++ b/include/legatus/status.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <optional>
+#include <variant>
+
+namespace legatus {
+
+enum class None : uint8_t {};
+
+template <typename T = None, typename E = None>
+class Status {
+  public:
+    template <typename U>
+    static Status<T, E> make_ok(U&& val);
+
+    template <typename U>
+    static Status<T, E> make_err(U&& val);
+
+    static Status<T, E> make_ok()
+        requires std::is_same_v<T, None>;
+
+    static Status<T, E> make_err()
+        requires std::is_same_v<E, None>;
+
+    bool is_ok() const;
+
+    bool is_err() const;
+
+    std::optional<T> ok();
+
+    std::optional<E> err();
+
+  private:
+    Status() = delete;
+
+    explicit Status(std::variant<T, E> state);
+
+    std::variant<T, E> state_;
+};
+
+template <typename T, typename E>
+template <typename U>
+Status<T, E> Status<T, E>::make_ok(U&& val) {
+    return Status(std::variant<T, E>(std::in_place_index<0>, std::forward<U>(val)));
+}
+
+template <typename T, typename E>
+Status<T, E> Status<T, E>::make_ok()
+    requires std::is_same_v<T, None>
+{
+    return make_ok(None{});
+}
+
+template <typename T, typename E>
+template <typename U>
+Status<T, E> Status<T, E>::make_err(U&& val) {
+    return Status(std::variant<T, E>(std::in_place_index<1>, std::forward<U>(val)));
+}
+
+template <typename T, typename E>
+Status<T, E> Status<T, E>::make_err()
+    requires std::is_same_v<E, None>
+{
+    return make_err(None{});
+}
+
+template <typename T, typename E>
+Status<T, E>::Status(std::variant<T, E> state) : state_(std::move(state)) {}
+
+template <typename T, typename E>
+bool Status<T, E>::is_ok() const {
+    return state_.index() == 0;
+}
+
+template <typename T, typename E>
+bool Status<T, E>::is_err() const {
+    return state_.index() == 1;
+}
+
+template <typename T, typename E>
+std::optional<T> Status<T, E>::ok() {
+    return is_ok() ? std::optional<T>(std::move(std::get<0>(state_))) : std::nullopt;
+}
+
+template <typename T, typename E>
+std::optional<E> Status<T, E>::err() {
+    return is_err() ? std::optional<E>(std::move(std::get<1>(state_))) : std::nullopt;
+}
+
+} // namespace legatus

--- a/test/io/event_test.cpp
+++ b/test/io/event_test.cpp
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 
+#include "legatus/status.h"
+
 #include "gtest/gtest.h"
 
 namespace legatus::io {
@@ -19,11 +21,12 @@ TEST(EventLoopTest, TimerOneshot) {
 
         called = true;
 
-        ev_loop.shutdown();
+        const Status<None, int> res = ev_loop.shutdown();
+        ASSERT_TRUE(res.is_ok());
     };
 
-    const int res = ev_loop.register_timer(timer_id, delay, false /* periodic */, cb);
-    ASSERT_EQ(0, res);
+    const Status<None, int> res = ev_loop.register_timer(timer_id, delay, false /* periodic */, cb);
+    ASSERT_TRUE(res.is_ok());
 
     ev_loop.run();
 
@@ -44,12 +47,13 @@ TEST(EventLoopTest, TimerPeriodic) {
         ++counter;
 
         if (counter == counter_max) {
-            ev_loop.shutdown();
+            const Status<None, int> res = ev_loop.shutdown();
+            ASSERT_TRUE(res.is_ok());
         }
     };
 
-    const int res = ev_loop.register_timer(timer_id, delay, true /* periodic */, cb);
-    ASSERT_EQ(0, res);
+    const Status<None, int> res = ev_loop.register_timer(timer_id, delay, true /* periodic */, cb);
+    ASSERT_TRUE(res.is_ok());
 
     ev_loop.run();
 
@@ -70,7 +74,8 @@ TEST(EventLoopTest, TimerUpdate) {
 
         called = true;
 
-        ev_loop.shutdown();
+        const Status<None, int> res = ev_loop.shutdown();
+        ASSERT_TRUE(res.is_ok());
     };
 
     const TimerCallback cb_periodic = [&](uint64_t id, int64_t err) {
@@ -78,13 +83,15 @@ TEST(EventLoopTest, TimerUpdate) {
         ASSERT_EQ(0, err);
         ++counter;
         if (counter == counter_max) {
-            const int res = ev_loop.register_timer(id, delay, false /* periodic */, cb_oneshot);
-            ASSERT_EQ(0, res);
+            const Status<None, int> res =
+                ev_loop.register_timer(id, delay, false /* periodic */, cb_oneshot);
+            ASSERT_TRUE(res.is_ok());
         }
     };
 
-    const int res = ev_loop.register_timer(timer_id, delay, true /* periodic */, cb_periodic);
-    ASSERT_EQ(0, res);
+    const Status<None, int> res =
+        ev_loop.register_timer(timer_id, delay, true /* periodic */, cb_periodic);
+    ASSERT_TRUE(res.is_ok());
 
     ev_loop.run();
 

--- a/test/status_test.cpp
+++ b/test/status_test.cpp
@@ -1,0 +1,97 @@
+#include "legatus/status.h"
+
+#include <cstdint>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace legatus {
+
+TEST(StatusTest, Ok) {
+    Status status = Status<int, int>::make_ok(-2);
+
+    ASSERT_TRUE(status.is_ok());
+    ASSERT_EQ(std::optional<int>(-2), status.ok());
+    ASSERT_FALSE(status.is_err());
+    ASSERT_EQ(std::nullopt, status.err());
+}
+
+TEST(StatusTest, Error) {
+    Status status = Status<int, std::string>::make_err("error message");
+
+    ASSERT_TRUE(status.is_err());
+    ASSERT_EQ(std::optional<std::string>("error message"), status.err());
+    ASSERT_FALSE(status.is_ok());
+    ASSERT_EQ(std::nullopt, status.ok());
+}
+
+template <typename T>
+struct ComplexResult {
+    std::unique_ptr<T> result;
+    std::vector<char> payload;
+};
+
+enum class ErrorCode : uint8_t {
+    NOT_FOUND,
+    INVALID,
+    UNKNOWN,
+};
+
+TEST(StatusTest, ComplexOk) {
+    const std::vector<char> payload = {'a', 'c', 'b'};
+    const int result_expected = 23;
+    ComplexResult<int> res{std::make_unique<int>(result_expected), payload};
+    Status status = Status<ComplexResult<int>, ErrorCode>::make_ok(std::move(res));
+
+    ASSERT_TRUE(status.is_ok());
+    ASSERT_FALSE(status.is_err());
+    ASSERT_EQ(std::nullopt, status.err());
+
+    std::optional<ComplexResult<int>> ok_val = status.ok();
+    ASSERT_TRUE(ok_val.has_value());
+    const ComplexResult<int>& val = ok_val.value(); // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(result_expected, *val.result);
+    ASSERT_EQ(payload, val.payload);
+}
+
+TEST(StatusTest, ComplexError) {
+    const std::vector<char> payload = {'a', 'c', 'b'};
+    ComplexResult<ErrorCode> res{std::make_unique<ErrorCode>(ErrorCode::INVALID), payload};
+    Status status = Status<float, ComplexResult<ErrorCode>>::make_err(std::move(res));
+
+    ASSERT_TRUE(status.is_err());
+    ASSERT_FALSE(status.is_ok());
+    ASSERT_EQ(std::nullopt, status.ok());
+
+    std::optional<ComplexResult<ErrorCode>> err_val = status.err();
+    ASSERT_TRUE(err_val.has_value());
+    const ComplexResult<ErrorCode>& val =
+        err_val.value(); // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(ErrorCode::INVALID, *val.result);
+    ASSERT_EQ(payload, val.payload);
+}
+
+TEST(StatusTest, NoneOk) {
+    Status status = Status<None, int>::make_ok();
+
+    ASSERT_TRUE(status.is_ok());
+    ASSERT_EQ(std::optional<None>({}), status.ok());
+    ASSERT_FALSE(status.is_err());
+    ASSERT_EQ(std::nullopt, status.err());
+}
+
+TEST(StatusTest, NoneErr) {
+    Status status = Status<int>::make_err();
+
+    ASSERT_TRUE(status.is_err());
+    ASSERT_EQ(std::optional<None>({}), status.err());
+    ASSERT_FALSE(status.is_ok());
+    ASSERT_EQ(std::nullopt, status.ok());
+}
+
+} // namespace legatus


### PR DESCRIPTION
Introduces a Rust-inspired Status type that is used for error propagation. The goal is to make error-handling intentional and clearer.