### PR TITLE
Implement file descriptor registration mechanism with EventLoop

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,19 +22,27 @@ IncludeIsMainRegex: "(_test)?$"
 IncludeBlocks: Regroup
 SortIncludes: true
 IncludeCategories:
-  - Regex:           '^<[a-z]+\.h>'       # <unistd.h>
+  - Regex:           '^<[a-z]+\.h>'             # <unistd.h>
     Priority:        1
-  - Regex:           '^<[a-z]+/.*\.h>'    # <sys/event.h>
+    SortPriority:    1
+  - Regex:           '^<[a-z]+/.*\.h>'          # <sys/event.h>
+    SortPriority:    2
     Priority:        1
   - Regex:           '^<c(errno|string|std).*>' # <cstring>
     Priority:        2
-  - Regex:           '^<[^/]*>'           # <other>
+    SortPriority:    3
+  - Regex:           '^<.*/'                    # <a/other>
     Priority:        3
-  - Regex:           '^<.*/'              # <a/other>
+    SortPriority:    5
+  - Regex:           '^<[^/]*>'                 # <other>
     Priority:        3
-  - Regex:           '^"gtest/.*"'        # "gtest/gtest.h"
+    SortPriority:    4
+  - Regex:           '^"gtest/.*"'              # "gtest/gtest.h"
+    SortPriority:    8
     Priority:        5
-  - Regex:           '^".*/'              # "b/project"
+  - Regex:           '^".*/'                    # "b/project"
+    SortPriority:    7
     Priority:        4
-  - Regex:           '^".*"'              # "project"
+  - Regex:           '^".*"'                    # "project"
+    SortPriority:    6
     Priority:        4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -readability-identifier-length
 
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: "(src|include)/.*"
 WarningsAsErrors: "*"
 
 CheckOptions:
@@ -25,11 +25,12 @@ CheckOptions:
  - { key: readability-identifier-naming.EnumConstantCase,      value: UPPER_CASE }
  - { key: readability-identifier-naming.GlobalConstantCase,    value: lower_case }
  - { key: readability-identifier-naming.GlobalConstantPrefix,  value: k_         }
- - { key: readability-identifier-naming.MemberConstantCase,    value: lower_case }
- - { key: readability-identifier-naming.MemberConstantPrefix,  value: k_         }
+ - { key: readability-identifier-naming.ConstantMemberCase,    value: lower_case }
+ - { key: readability-identifier-naming.ConstantMemberPrefix,  value: k_         }
+ - { key: readability-identifier-naming.ConstantMemberSuffix,  value: _          }
  - { key: readability-identifier-naming.StaticConstantCase,    value: lower_case }
  - { key: readability-identifier-naming.StaticConstantPrefix,  value: k_         }
 
- - { key: bugprone-unused-return-value.CheckedFunctions, value:   '^.*$' }
+ - { key: bugprone-unused-return-value.CheckedFunctions,   value: '^.*$' }
  - { key: bugprone-unused-return-value.CheckedReturnTypes, value: '^.*$' }
- - { key: bugprone-unused-return-value.AllowCastToVoid,    value:  true}
+ - { key: bugprone-unused-return-value.AllowCastToVoid,    value:  true  }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,7 @@ if(ENABLE_MSAN)
         )
         add_link_options(-fsanitize=address)
     else()
-        add_compile_options(
-            -fsanitize=memory
-            -fno-omit-frame-pointer
+        add_compile_options( -fsanitize=memory -fno-omit-frame-pointer
             -g
         )
         add_link_options(-fsanitize=memory)
@@ -78,6 +76,7 @@ configure_file(${LEGATUS_SRC_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/gen
 set(LEGATUS_SRC_LIST
     ${LEGATUS_SRC_DIR}/legatus.cpp
     ${LEGATUS_SRC_DIR}/io/event.cpp
+    ${LEGATUS_SRC_DIR}/io/socket.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/gen/version.cpp
 )
 
@@ -98,7 +97,9 @@ target_link_libraries(legatus-tests legatus-lib gtest_main)
 
 add_test(unit-tests legatus-tests)
 
+file(GLOB_RECURSE HDR_FILES "${LEGATUS_SRC_DIR}/*.h" "${LEGATUS_INCLUDE_DIR}/*.h")
 add_custom_target(lint
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/run-clang-tidy.py -p=${CMAKE_BINARY_DIR} -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
+  COMMAND /usr/local/bin/clang-tidy -p ${CMAKE_BINARY_DIR} --config-file ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy ${HDR_FILES}
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/run-clang-tidy.py -p=${CMAKE_BINARY_DIR} -config-file=${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy
   COMMENT "Running clang-tidy..."
 )

--- a/include/legatus/io/event.h
+++ b/include/legatus/io/event.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sys/event.h>
-
 #include <cstdint>
 
 #include <functional>
@@ -11,7 +9,9 @@
 
 namespace legatus::io {
 
-using TimerCallback = std::function<void(uint64_t, int64_t)>;
+using TimerEventCb = std::function<void(uint64_t, Status<None, int64_t>)>;
+using FdEventIOCb = std::function<void(uint64_t, Status<int64_t, uint32_t>)>;
+using FdEventEOFCb = std::function<void(uint64_t, Status<int64_t, uint32_t>)>;
 
 class EventLoop {
   public:
@@ -23,21 +23,37 @@ class EventLoop {
 
     ~EventLoop();
 
-    Status<None, int> shutdown() const;
-
+    Status<None, int> register_fd_read(int fd, const FdEventIOCb& cb);
+    Status<None, int> register_fd_write(int fd, const FdEventIOCb& cb);
+    Status<None, int> register_fd_eof(int fd, const FdEventEOFCb& cb);
     Status<None, int> register_timer(uint64_t id,
                                      uint64_t timeout,
                                      bool periodic,
-                                     const TimerCallback& cb);
+                                     const TimerEventCb& cb);
+
+    Status<None, int> remove_fd_read(int fd);
+    Status<None, int> remove_fd_write(int fd);
+    Status<None, int> remove_fd_eof(int fd);
+    Status<None, int> remove_timer(uint64_t id);
 
     void run();
+
+    Status<None, int> shutdown() const;
 
   private:
     static constexpr uint64_t k_shutdown_event_id = 19;
 
     int kq_;
     bool done_ = false;
-    std::unordered_map<uint64_t, TimerCallback> timers_;
+    std::unordered_map<uint64_t, TimerEventCb> timers_;
+    std::unordered_map<uint64_t, FdEventIOCb> fd_read_;
+    std::unordered_map<uint64_t, FdEventIOCb> fd_write_;
+    std::unordered_map<uint64_t, FdEventEOFCb> fd_eof_;
+
+    void handle_shutdown(uint64_t id);
+    void handle_timer(uint64_t id, uint16_t flags, int64_t data);
+    void handle_fd_read(uint64_t fd, uint16_t flags, uint32_t fflags, int64_t data);
+    void handle_fd_write(uint64_t fd, uint16_t flags, uint32_t fflags, int64_t data);
 
     void do_shutdown();
 };

--- a/include/legatus/io/socket.h
+++ b/include/legatus/io/socket.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+#include <span>
+#include <string>
+
+#include "legatus/status.h"
+
+namespace legatus::io {
+
+class Socket {
+  public:
+    Socket();
+    explicit Socket(int fd);
+    Socket(const Socket&) = delete;
+    Socket& operator=(const Socket&) = delete;
+    Socket(Socket&& other) noexcept;
+    Socket& operator=(Socket&&) = delete;
+    virtual ~Socket();
+
+    Status<None, int> set_non_blocking() const;
+
+    Status<None, int> send_all(std::span<uint8_t> buf_view) const;
+    Status<std::span<uint8_t>, int> recv_some(std::span<uint8_t> buf_view) const;
+
+    Status<None, int> close();
+
+    int get_fd() const;
+
+  private:
+    int fd_;
+};
+
+class ClientSocket : public Socket {
+  public:
+    ClientSocket() = default;
+
+    Status<None, int> connect(const std::string& address, int port) const;
+};
+
+class ServerSocket : public Socket {
+  public:
+    ServerSocket();
+
+    Status<None, int> listen(int port, int backlog) const;
+    Status<Socket, int> accept() const;
+};
+
+} // namespace legatus::io

--- a/include/legatus/status.h
+++ b/include/legatus/status.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <optional>
+#include <cstdint>
+
+#include <utility>
 #include <variant>
 
 namespace legatus {
@@ -26,9 +28,9 @@ class Status {
 
     bool is_err() const;
 
-    std::optional<T> ok();
+    T ok();
 
-    std::optional<E> err();
+    E err();
 
   private:
     Status() = delete;
@@ -78,13 +80,13 @@ bool Status<T, E>::is_err() const {
 }
 
 template <typename T, typename E>
-std::optional<T> Status<T, E>::ok() {
-    return is_ok() ? std::optional<T>(std::move(std::get<0>(state_))) : std::nullopt;
+T Status<T, E>::ok() {
+    return std::move(std::get<0>(state_));
 }
 
 template <typename T, typename E>
-std::optional<E> Status<T, E>::err() {
-    return is_err() ? std::optional<E>(std::move(std::get<1>(state_))) : std::nullopt;
+E Status<T, E>::err() {
+    return std::move(std::get<1>(state_));
 }
 
 } // namespace legatus

--- a/src/io/event.cpp
+++ b/src/io/event.cpp
@@ -1,7 +1,7 @@
 #include "legatus/io/event.h"
 
-#include <sys/event.h>
 #include <unistd.h>
+#include <sys/event.h>
 
 #include <cerrno>
 #include <cstdint>
@@ -34,15 +34,56 @@ EventLoop::~EventLoop() {
     }
 }
 
+Status<None, int> EventLoop::register_fd_read(int fd, const FdEventIOCb& cb) {
+    struct kevent ev{};
+
+    EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to register read filter for fd");
+
+        return Status<None, int>::make_err(errno);
+    };
+    fd_read_[fd] = cb;
+
+    return Status<None, int>::make_ok();
+}
+
+Status<None, int> EventLoop::register_fd_write(int fd, const FdEventIOCb& cb) {
+    struct kevent ev{};
+
+    EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to register write filter for fd");
+
+        return Status<None, int>::make_err(errno);
+    };
+    fd_write_[fd] = cb;
+
+    return Status<None, int>::make_ok();
+}
+
+Status<None, int> EventLoop::register_fd_eof(int fd, const FdEventEOFCb& cb) {
+    if (!fd_read_.contains(fd) && !fd_write_.contains(fd)) {
+        return Status<None, int>::make_err(0);
+    }
+
+    fd_eof_[fd] = cb;
+
+    return Status<None, int>::make_ok();
+}
+
 Status<None, int> EventLoop::register_timer(uint64_t id,
                                             uint64_t timeout,
                                             bool periodic,
-                                            const TimerCallback& cb) {
+                                            const TimerEventCb& cb) {
     struct kevent ev{};
     const uint16_t oneshot = periodic ? 0 : EV_ONESHOT;
 
     EV_SET(&ev, id, EVFILT_TIMER, EV_ADD | oneshot, NOTE_NSECONDS, timeout, nullptr);
-    timers_[id] = cb;
 
     const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
     if (ret == -1) {
@@ -50,8 +91,111 @@ Status<None, int> EventLoop::register_timer(uint64_t id,
 
         return Status<None, int>::make_err(errno);
     };
+    timers_[id] = cb;
 
     return Status<None, int>::make_ok();
+}
+
+Status<None, int> EventLoop::remove_fd_read(int fd) {
+    if (fd_read_.erase(fd) != 1) {
+        return Status<None, int>::make_err(0);
+    }
+
+    struct kevent ev{};
+
+    EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to remove read filter for fd");
+
+        return Status<None, int>::make_err(errno);
+    };
+
+    return Status<None, int>::make_ok();
+}
+
+Status<None, int> EventLoop::remove_fd_write(int fd) {
+    if (fd_write_.erase(fd) != 1) {
+        return Status<None, int>::make_err(0);
+    }
+
+    struct kevent ev{};
+
+    EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to remove write filter for fd");
+
+        return Status<None, int>::make_err(errno);
+    };
+
+    return Status<None, int>::make_ok();
+}
+
+Status<None, int> EventLoop::remove_fd_eof(int fd) {
+    if (fd_eof_.erase(fd) != 1) {
+        return Status<None, int>::make_err(0);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+Status<None, int> EventLoop::remove_timer(uint64_t id) {
+    if (timers_.erase(id) != 1) {
+        return Status<None, int>::make_err(0);
+    }
+
+    struct kevent ev{};
+
+    EV_SET(&ev, id, EVFILT_TIMER, EV_DELETE, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to remove timer filter");
+
+        return Status<None, int>::make_err(errno);
+    };
+
+    return Status<None, int>::make_ok();
+}
+
+void EventLoop::run() {
+    struct kevent ev{};
+
+    while (!done_) {
+        const int ret = kevent(kq_, nullptr, 0, &ev, 1, nullptr);
+        if (ret == -1) {
+            perror("failed to wait for events");
+            continue;
+        }
+
+        switch (ev.filter) {
+        case EVFILT_USER: {
+            handle_shutdown(ev.ident);
+            break;
+        }
+
+        case EVFILT_TIMER: {
+            handle_timer(ev.ident, ev.flags, ev.data);
+            break;
+        }
+
+        case EVFILT_READ: {
+            handle_fd_read(ev.ident, ev.flags, ev.fflags, ev.data);
+            break;
+        }
+
+        case EVFILT_WRITE: {
+            handle_fd_write(ev.ident, ev.flags, ev.fflags, ev.data);
+            break;
+        }
+
+        default:
+            perror("unknown event type");
+        }
+    }
 }
 
 Status<None, int> EventLoop::shutdown() const {
@@ -68,39 +212,62 @@ Status<None, int> EventLoop::shutdown() const {
     return Status<None, int>::make_ok();
 }
 
-void EventLoop::run() {
-    struct kevent ev{};
+void EventLoop::handle_shutdown(const uint64_t id) {
+    if (id == k_shutdown_event_id) {
+        done_ = true;
+    }
+}
 
-    while (!done_) {
-        const int ret = kevent(kq_, nullptr, 0, &ev, 1, nullptr);
-        if (ret == -1) {
-            perror("failed to wait for events");
-            continue;
+void EventLoop::handle_timer(const uint64_t id, const uint16_t flags, const int64_t data) {
+    if (!timers_.contains(id)) {
+        return;
+    }
+
+    // TODO (whalbawi): Confirm what happens when a timer fails and how errors are reported.
+    const TimerEventCb& cb = timers_[id];
+    if ((flags & EV_ERROR) != 0) {
+        cb(id, Status<None, int64_t>::make_err(data));
+    } else {
+        cb(id, Status<None, int64_t>::make_ok());
+    }
+}
+
+void EventLoop::handle_fd_read(const uint64_t fd,
+                               const uint16_t flags,
+                               const uint32_t fflags,
+                               const int64_t data) {
+    if (fd_read_.contains(fd)) {
+        const FdEventIOCb& cb = fd_read_[fd];
+        if ((flags & EV_ERROR) != 0) {
+            cb(fd, Status<int64_t, uint32_t>::make_err(fflags));
+        } else {
+            cb(fd, Status<int64_t, uint32_t>::make_ok(data));
         }
+    }
 
-        const uint64_t id = ev.ident;
+    if ((flags & EV_EOF) != 0 && fd_eof_.contains(fd)) {
+        const FdEventEOFCb& cb = fd_eof_[fd];
+        cb(fd, Status<int64_t, uint32_t>::make_ok(data));
+    }
+}
 
-        switch (ev.filter) {
-        case EVFILT_USER: {
-            if (id == k_shutdown_event_id) {
-                done_ = true;
-            }
-            break;
-        }
+void EventLoop::handle_fd_write(const uint64_t fd,
+                                const uint16_t flags,
+                                const uint32_t fflags,
+                                const int64_t data) {
+    if (!fd_write_.contains(fd)) {
+        return;
+    }
+    const FdEventIOCb& cb = fd_write_[fd];
+    if ((flags & EV_ERROR) != 0) {
+        cb(fd, Status<int64_t, uint32_t>::make_err(fflags));
+    } else {
+        cb(fd, Status<int64_t, uint32_t>::make_ok(data));
+    }
 
-        case EVFILT_TIMER: {
-            const auto& cb = timers_[id];
-            if ((ev.flags & EV_ERROR) != 0) {
-                cb(ev.ident, ev.data);
-            } else {
-                cb(ev.ident, 0);
-            }
-            break;
-        }
-
-        default:
-            perror("unknown event type");
-        }
+    if ((flags & EV_EOF) != 0 && fd_eof_.contains(fd)) {
+        const FdEventEOFCb& cb = fd_eof_[fd];
+        cb(fd, Status<int64_t, uint32_t>::make_ok(data));
     }
 }
 

--- a/src/io/socket.cpp
+++ b/src/io/socket.cpp
@@ -1,0 +1,167 @@
+#include "legatus/io/socket.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h> // IWYU pragma: keep -- for ssize_t
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+
+#include <span>
+#include <stdexcept>
+#include <string>
+
+#include "legatus/status.h"
+
+namespace {
+
+int do_fcntl(int fd, int cmd, int flags) {
+    return fcntl(fd, cmd, flags); // NOLINT(cppcoreguidelines-pro-type-vararg, misc-include-cleaner)
+}
+
+struct sockaddr* endpoint_to_sockaddr(const std::string& address,
+                                      int port,
+                                      struct sockaddr_in& addr_in) {
+    addr_in.sin_family = AF_INET;
+    addr_in.sin_port = htons(port); // NOLINT(misc-include-cleaner)
+    addr_in.sin_addr.s_addr = inet_addr(address.c_str());
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<struct sockaddr*>(&addr_in);
+}
+
+} // namespace
+
+namespace legatus::io {
+
+Socket::Socket() : fd_(socket(AF_INET, SOCK_STREAM, 0)) {
+    if (fd_ == -1) {
+        throw std::runtime_error("failed to create client socket");
+    }
+}
+
+Socket::Socket(int fd) : fd_(fd) {}
+
+Socket::Socket(Socket&& other) noexcept : fd_(other.fd_) {
+    other.fd_ = -1;
+}
+
+Socket::~Socket() {
+    (void)close();
+}
+
+Status<None, int> Socket::set_non_blocking() const {
+    const int flags = do_fcntl(fd_, F_GETFL, 0); // NOLINT(misc-include-cleaner) -- for F_GETFL
+    if (flags == -1) {
+        perror("failed to get socket flags");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    // NOLINTNEXTLINE(misc-include-cleaner) -- for F_SETFL, O_NONBLOCK
+    if (do_fcntl(fd_, F_SETFL, flags | O_NONBLOCK) == -1) {
+        perror("failed to put socket in non-blocking mode");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+Status<None, int> Socket::send_all(std::span<uint8_t> buf) const {
+    while (!buf.empty()) {
+        // NOLINTNEXTLINE(misc-include-cleaner) -- for ssize_t
+        const ssize_t len = write(fd_, buf.data(), buf.size());
+        if (len == -1) {
+            perror("failed to write to socket");
+
+            return Status<None, int>::make_err(errno);
+        }
+        buf = buf.subspan(len);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+Status<std::span<uint8_t>, int> Socket::recv_some(std::span<uint8_t> buf_view) const {
+    const ssize_t len = read(fd_, buf_view.data(), buf_view.size());
+    if (len == -1) {
+        perror("failed to read from connection");
+
+        return Status<std::span<uint8_t>, int>::make_err(errno);
+    }
+
+    return Status<std::span<uint8_t>, int>::make_ok(buf_view.first(len));
+}
+
+Status<None, int> Socket::close() {
+    const int fd = fd_;
+    if (fd != -1 && ::close(fd) == -1) {
+        perror("failed to close socket fd");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    fd_ = -1;
+
+    return Status<None, int>::make_ok();
+}
+
+int Socket::get_fd() const {
+    return fd_;
+}
+
+Status<None, int> ClientSocket::connect(const std::string& address, int port) const {
+    struct sockaddr_in addr_in{};
+    struct sockaddr* addr = endpoint_to_sockaddr(address, port, addr_in);
+
+    if (::connect(get_fd(), addr, sizeof(*addr)) == -1) {
+        perror("failed to connect to server");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+ServerSocket::ServerSocket() {
+    int enable = 1;
+    if (setsockopt(get_fd(), SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) == -1) {
+        throw std::runtime_error("failed to create client socket");
+    }
+}
+
+Status<None, int> ServerSocket::listen(int port, int backlog) const {
+    struct sockaddr_in addr_in{};
+    struct sockaddr* addr = endpoint_to_sockaddr("0.0.0.0", port, addr_in);
+    if (bind(get_fd(), addr, sizeof(*addr)) == -1) {
+        perror("failed to bind to socket");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    if (::listen(get_fd(), backlog) < 0) {
+        perror("failed to listen for incoming connections");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+Status<Socket, int> ServerSocket::accept() const {
+    const int peer_fd = ::accept(get_fd(), nullptr, nullptr);
+    if (peer_fd == -1) {
+        perror("failed to accept connection");
+
+        return Status<Socket, int>::make_err(errno);
+    }
+
+    return Status<Socket, int>::make_ok(Socket(peer_fd));
+}
+
+} // namespace legatus::io

--- a/test/io/event_test.cpp
+++ b/test/io/event_test.cpp
@@ -2,27 +2,39 @@
 
 #include "legatus/io/event.h"
 
+#include <cerrno>
 #include <cstdint>
+#include <cstdio>
 
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <span>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "legatus/io/socket.h"
 #include "legatus/status.h"
 
 #include "gtest/gtest.h"
 
 namespace legatus::io {
+
 TEST(EventLoopTest, TimerOneshot) {
     legatus::io::EventLoop ev_loop;
     int timer_id = 1;
     const uint64_t delay = 5e8;
     bool called = false;
 
-    const TimerCallback cb = [&](uint64_t id, int64_t err) {
-        ASSERT_EQ(timer_id, id);
-        ASSERT_EQ(0, err);
+    const TimerEventCb cb = [&](uint64_t id, Status<None, int64_t> status) {
+        EXPECT_EQ(timer_id, id);
+        EXPECT_TRUE(status.is_ok());
 
         called = true;
 
         const Status<None, int> res = ev_loop.shutdown();
-        ASSERT_TRUE(res.is_ok());
+        EXPECT_TRUE(res.is_ok());
     };
 
     const Status<None, int> res = ev_loop.register_timer(timer_id, delay, false /* periodic */, cb);
@@ -40,15 +52,15 @@ TEST(EventLoopTest, TimerPeriodic) {
     int counter = 0;
     int counter_max = 4;
 
-    const TimerCallback cb = [&](uint64_t id, int64_t err) {
-        ASSERT_EQ(timer_id, id);
-        ASSERT_EQ(0, err);
+    const TimerEventCb cb = [&](uint64_t id, Status<None, int64_t> status) {
+        EXPECT_EQ(timer_id, id);
+        EXPECT_TRUE(status.is_ok());
 
         ++counter;
 
         if (counter == counter_max) {
             const Status<None, int> res = ev_loop.shutdown();
-            ASSERT_TRUE(res.is_ok());
+            EXPECT_TRUE(res.is_ok());
         }
     };
 
@@ -68,24 +80,24 @@ TEST(EventLoopTest, TimerUpdate) {
     int counter_max = 4;
     bool called = false;
 
-    const TimerCallback cb_oneshot = [&](uint64_t id, int64_t err) {
-        ASSERT_EQ(timer_id, id);
-        ASSERT_EQ(0, err);
+    const TimerEventCb cb_oneshot = [&](uint64_t id, Status<None, int64_t> status) {
+        EXPECT_EQ(timer_id, id);
+        EXPECT_TRUE(status.is_ok());
 
         called = true;
 
         const Status<None, int> res = ev_loop.shutdown();
-        ASSERT_TRUE(res.is_ok());
+        EXPECT_TRUE(res.is_ok());
     };
 
-    const TimerCallback cb_periodic = [&](uint64_t id, int64_t err) {
-        ASSERT_EQ(timer_id, id);
-        ASSERT_EQ(0, err);
+    const TimerEventCb cb_periodic = [&](uint64_t id, Status<None, int64_t> status) {
+        EXPECT_EQ(timer_id, id);
+        EXPECT_TRUE(status.is_ok());
         ++counter;
         if (counter == counter_max) {
             const Status<None, int> res =
                 ev_loop.register_timer(id, delay, false /* periodic */, cb_oneshot);
-            ASSERT_TRUE(res.is_ok());
+            EXPECT_TRUE(res.is_ok());
         }
     };
 
@@ -96,6 +108,233 @@ TEST(EventLoopTest, TimerUpdate) {
     ev_loop.run();
 
     ASSERT_EQ(counter_max, counter);
+}
+
+TEST(EventLoopTest, BadFd) {
+    EventLoop ev_loop{};
+    const int bogus_fd = 5;
+
+    Status<None, int> status =
+        ev_loop.register_fd_read(bogus_fd, [](uint64_t, Status<int64_t, uint32_t>) {});
+    ASSERT_TRUE(status.is_err());
+    ASSERT_EQ(EBADF, status.err());
+
+    status = ev_loop.register_fd_write(bogus_fd, [](uint64_t, Status<int64_t, uint32_t>) {});
+    ASSERT_TRUE(status.is_err());
+    ASSERT_EQ(EBADF, status.err());
+
+    status = ev_loop.register_fd_eof(bogus_fd, [](uint64_t, Status<int64_t, uint32_t>) {});
+    ASSERT_TRUE(status.is_err());
+    ASSERT_EQ(0, status.err());
+}
+
+class IncrementServer {
+  public:
+    IncrementServer() = delete;
+    IncrementServer(const IncrementServer&) = delete;
+    IncrementServer& operator=(const IncrementServer&) = delete;
+    IncrementServer(IncrementServer&&) = delete;
+    IncrementServer& operator=(IncrementServer&&) = delete;
+
+    explicit IncrementServer(int port) : port_(port), socket_{ServerSocket()}, running_{false} {}
+
+    ~IncrementServer() {
+        (void)socket_.close();
+    }
+
+    void start() {
+        if (socket_.listen(port_, 1).is_err()) {
+            return;
+        }
+
+        running_.store(true);
+
+        while (running_.load()) {
+            Status<Socket, int> peer_socket_status = socket_.accept();
+            if (peer_socket_status.is_err()) {
+                continue;
+            }
+
+            Socket peer_socket = peer_socket_status.ok();
+            for (;;) {
+                std::span<uint8_t> buf_view{buf_};
+                Status<std::span<uint8_t>, int> recv_some_res = peer_socket.recv_some(buf_view);
+                if (recv_some_res.is_err()) {
+                    (void)peer_socket.close();
+                    break;
+                }
+
+                buf_view = recv_some_res.ok();
+
+                if (buf_view.empty()) {
+                    (void)peer_socket.close();
+                    break;
+                }
+
+                for (auto& elem : buf_view) {
+                    elem += 1;
+                }
+
+                if (peer_socket.send_all(buf_view).is_err()) {
+                    (void)peer_socket.close();
+                    break;
+                }
+            }
+        }
+    }
+
+    bool running() {
+        return running_.load();
+    }
+
+    void stop() {
+        running_.store(false);
+    }
+
+  private:
+    static constexpr size_t k_buf_sz = 16;
+
+    int port_;
+    ServerSocket socket_;
+    std::atomic_bool running_;
+    std::array<uint8_t, k_buf_sz> buf_{};
+};
+
+class Request {
+  public:
+    enum class State : uint8_t {
+        WRITE,
+        READ,
+        END,
+    };
+
+    explicit Request(Socket&& socket,
+                     std::span<uint8_t> send_buf_view,
+                     std::span<uint8_t> recv_buf_view)
+        : socket_(std::move(socket)),
+          send_buf_view_{send_buf_view},
+          recv_buf_view_{recv_buf_view} {}
+
+    void write(size_t max_len) {
+        const size_t len = std::min<size_t>(send_buf_view_.size(), max_len);
+        const Status<None, int> res = socket_.send_all(send_buf_view_.first(len));
+        if (res.is_err()) {
+            return;
+        }
+
+        send_buf_view_ = send_buf_view_.subspan(len);
+        if (send_buf_view_.empty()) {
+            state_ = State::READ;
+        }
+    }
+
+    void read(size_t max_len) {
+        const size_t len = std::min<size_t>(recv_buf_view_.size(), max_len);
+        Status<std::span<uint8_t>, int> res = socket_.recv_some(recv_buf_view_.first(len));
+        if (res.is_err()) {
+            return;
+        }
+
+        recv_buf_view_ = recv_buf_view_.subspan(res.ok().size());
+        if (recv_buf_view_.empty()) {
+            state_ = State::END;
+        }
+    }
+
+    void end() {
+        (void)socket_.close();
+    }
+
+    State get_state() {
+        return state_;
+    }
+
+  private:
+    Socket socket_;
+    std::span<uint8_t> send_buf_view_;
+    std::span<uint8_t> recv_buf_view_;
+
+    State state_ = State::WRITE;
+};
+
+TEST(EventLoopTest, Server) {
+    const int port = 8080;
+    IncrementServer server{port};
+
+    std::thread server_thread{[&] { server.start(); }};
+    while (!server.running()) {
+    }
+
+    ClientSocket socket{};
+    ASSERT_TRUE(socket.connect("127.0.0.1", port).is_ok());
+    ASSERT_TRUE(socket.set_non_blocking().is_ok());
+    constexpr size_t buf_sz = 512;
+
+    std::array<uint8_t, buf_sz> send_buf{};
+    for (size_t i = 0; i < send_buf.size(); ++i) {
+        send_buf.at(i) = 'a' + i;
+    }
+
+    std::array<uint8_t, buf_sz> recv_buf{};
+
+    const int conn_fd = socket.get_fd();
+    Request request{std::move(socket), std::span<uint8_t>{send_buf}, std::span<uint8_t>{recv_buf}};
+
+    EventLoop ev_loop{};
+    const FdEventEOFCb eof_cb = [&](uint64_t id, Status<int64_t, uint32_t> status) {
+        (void)id;
+        (void)status;
+        FAIL();
+    };
+
+    const FdEventIOCb read_cb = [&](uint64_t id, Status<int64_t, uint32_t> status) {
+        EXPECT_EQ(conn_fd, id);
+        EXPECT_TRUE(status.is_ok());
+
+        switch (request.get_state()) {
+        case Request::State::READ: {
+            request.read(status.ok());
+            break;
+        }
+        default: {
+            return;
+        }
+        }
+    };
+
+    const FdEventIOCb write_cb = [&](uint64_t id, Status<int64_t, uint32_t> status) {
+        EXPECT_EQ(conn_fd, id);
+        EXPECT_TRUE(status.is_ok());
+
+        switch (request.get_state()) {
+        case Request::State::WRITE: {
+            request.write(status.ok());
+            break;
+        }
+        case Request::State::END: {
+            server.stop();
+            request.end();
+            ASSERT_TRUE(ev_loop.shutdown().is_ok());
+            break;
+        }
+        default: {
+            return;
+        }
+        }
+    };
+
+    ASSERT_TRUE(ev_loop.register_fd_write(conn_fd, write_cb).is_ok());
+    ASSERT_TRUE(ev_loop.register_fd_read(conn_fd, read_cb).is_ok());
+    ASSERT_TRUE(ev_loop.register_fd_eof(conn_fd, eof_cb).is_ok());
+
+    ev_loop.run();
+    server_thread.join();
+
+    for (size_t i = 0; i < recv_buf.size(); ++i) {
+        const uint8_t received = recv_buf.at(i);
+        const uint8_t expected = send_buf.at(i) + 1;
+        ASSERT_EQ(expected, received);
+    }
 }
 
 } // namespace legatus::io

--- a/test/status_test.cpp
+++ b/test/status_test.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -16,18 +15,16 @@ TEST(StatusTest, Ok) {
     Status status = Status<int, int>::make_ok(-2);
 
     ASSERT_TRUE(status.is_ok());
-    ASSERT_EQ(std::optional<int>(-2), status.ok());
+    ASSERT_EQ(-2, status.ok());
     ASSERT_FALSE(status.is_err());
-    ASSERT_EQ(std::nullopt, status.err());
 }
 
 TEST(StatusTest, Error) {
     Status status = Status<int, std::string>::make_err("error message");
 
     ASSERT_TRUE(status.is_err());
-    ASSERT_EQ(std::optional<std::string>("error message"), status.err());
+    ASSERT_EQ(std::string("error message"), status.err());
     ASSERT_FALSE(status.is_ok());
-    ASSERT_EQ(std::nullopt, status.ok());
 }
 
 template <typename T>
@@ -50,13 +47,10 @@ TEST(StatusTest, ComplexOk) {
 
     ASSERT_TRUE(status.is_ok());
     ASSERT_FALSE(status.is_err());
-    ASSERT_EQ(std::nullopt, status.err());
 
-    std::optional<ComplexResult<int>> ok_val = status.ok();
-    ASSERT_TRUE(ok_val.has_value());
-    const ComplexResult<int>& val = ok_val.value(); // NOLINT(bugprone-unchecked-optional-access)
-    ASSERT_EQ(result_expected, *val.result);
-    ASSERT_EQ(payload, val.payload);
+    const ComplexResult<int> cplx_res = status.ok();
+    ASSERT_EQ(result_expected, *cplx_res.result);
+    ASSERT_EQ(payload, cplx_res.payload);
 }
 
 TEST(StatusTest, ComplexError) {
@@ -66,32 +60,26 @@ TEST(StatusTest, ComplexError) {
 
     ASSERT_TRUE(status.is_err());
     ASSERT_FALSE(status.is_ok());
-    ASSERT_EQ(std::nullopt, status.ok());
 
-    std::optional<ComplexResult<ErrorCode>> err_val = status.err();
-    ASSERT_TRUE(err_val.has_value());
-    const ComplexResult<ErrorCode>& val =
-        err_val.value(); // NOLINT(bugprone-unchecked-optional-access)
-    ASSERT_EQ(ErrorCode::INVALID, *val.result);
-    ASSERT_EQ(payload, val.payload);
+    const ComplexResult<ErrorCode> cplx_res = status.err();
+    ASSERT_EQ(ErrorCode::INVALID, *cplx_res.result);
+    ASSERT_EQ(payload, cplx_res.payload);
 }
 
 TEST(StatusTest, NoneOk) {
     Status status = Status<None, int>::make_ok();
 
     ASSERT_TRUE(status.is_ok());
-    ASSERT_EQ(std::optional<None>({}), status.ok());
+    ASSERT_EQ(None{}, status.ok());
     ASSERT_FALSE(status.is_err());
-    ASSERT_EQ(std::nullopt, status.err());
 }
 
 TEST(StatusTest, NoneErr) {
     Status status = Status<int>::make_err();
 
     ASSERT_TRUE(status.is_err());
-    ASSERT_EQ(std::optional<None>({}), status.err());
+    ASSERT_EQ(None{}, status.err());
     ASSERT_FALSE(status.is_ok());
-    ASSERT_EQ(std::nullopt, status.ok());
 }
 
 } // namespace legatus


### PR DESCRIPTION
Adds the ability to register file descriptors with EventLoop. The caller will receive readiness notifications for read, write and close and operations.

Additionally, rework the `Status` APIs to directly return the held types instead of wrapping with `std::optional`.