### PR TITLE
Implement fiber scheduler and async socket primitive

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,8 @@ Checks: >
   performance-*,
   readability-*,
   -bugprone-easily-swappable-parameters,
-  -readability-identifier-length
+  -readability-identifier-length,
+  -cppcoreguidelines-non-private-member-variables-in-classes
 
 HeaderFilterRegex: "(src|include)/.*"
 WarningsAsErrors: "*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ if(ENABLE_MSAN)
         )
         add_link_options(-fsanitize=address)
     else()
-        add_compile_options( -fsanitize=memory -fno-omit-frame-pointer
+        add_compile_options( -fsanitize=memory
+            -fno-omit-frame-pointer
             -g
         )
         add_link_options(-fsanitize=memory)
@@ -75,9 +76,11 @@ configure_file(${AXLE_SRC_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/gen/ve
 
 # Source files
 set(AXLE_SRC_LIST
+    ${AXLE_SRC_DIR}/async_socket.cpp
     ${AXLE_SRC_DIR}/axle.cpp
     ${AXLE_SRC_DIR}/event.cpp
     ${AXLE_SRC_DIR}/fiber.cpp
+    ${AXLE_SRC_DIR}/scheduler.cpp
     ${AXLE_SRC_DIR}/socket.cpp
     ${AXLE_SRC_DIR}/fiber_arm64.cpp
     ${AXLE_SRC_DIR}/asm/fiber_arm64.s
@@ -104,6 +107,9 @@ add_test(unit-tests axle-tests)
 
 add_executable(echo_server ${AXLE_EXAMPLES_DIR}/echo_server/main.cpp)
 target_link_libraries(echo_server axle-lib)
+
+add_executable(async_echo_server ${AXLE_EXAMPLES_DIR}/async_echo_server/main.cpp)
+target_link_libraries(async_echo_server axle-lib)
 
 file(GLOB_RECURSE HDR_FILES "${AXLE_SRC_DIR}/*.h" "${AXLE_INCLUDE_DIR}/*.h")
 add_custom_target(lint

--- a/examples/async_echo_server/main.cpp
+++ b/examples/async_echo_server/main.cpp
@@ -1,0 +1,77 @@
+#include <cstddef>
+#include <cstdint>
+
+#include <array>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <span>
+#include <utility>
+
+#include "axle/async_socket.h"
+#include "axle/scheduler.h"
+#include "axle/status.h"
+
+namespace {
+
+void connection_handler(const std::shared_ptr<axle::AsyncSocket>& socket) {
+    constexpr size_t buf_sz = 16 * 1024UL;
+    std::array<uint8_t, buf_sz> buf{};
+    const std::span<uint8_t> buf_view{buf};
+
+    for (;;) {
+        axle::Status<std::span<uint8_t>, int> recv_status = socket->recv_some(buf_view);
+        if (recv_status.is_err()) {
+            (void)socket->close();
+            return;
+        }
+
+        const std::span<uint8_t> recv_buf = recv_status.ok();
+        if (recv_buf.empty()) {
+            (void)socket->close();
+            return;
+        }
+
+        const axle::Status<axle::None, int> send_status = socket->send_all(recv_buf);
+        if (send_status.is_err()) {
+            (void)socket->close();
+            return;
+        }
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    constexpr int port = 8080;
+    constexpr int backlog = 128;
+    axle::Scheduler::init();
+
+    try {
+        const axle::AsyncServerSocket socket{};
+        axle::Status<axle::None, int> listen_status = socket.listen(port, backlog);
+        if (listen_status.is_err()) {
+            std::cerr << "could not listen on socket - error: " << listen_status.err() << "\n";
+            return -1;
+        }
+
+        for (;;) {
+            axle::Status<axle::AsyncSocket, int> accept_status = socket.accept();
+            if (accept_status.is_err()) {
+                std::cerr << "could not accept connection - error: " << accept_status.err() << "\n";
+                return -1;
+            }
+
+            std::shared_ptr<axle::AsyncSocket> peer_socket =
+                std::make_shared<axle::AsyncSocket>(accept_status.ok());
+
+            axle::Scheduler::schedule([s = std::move(peer_socket)]() { connection_handler(s); });
+        }
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        return -1;
+    }
+}

--- a/examples/echo_server/main.cpp
+++ b/examples/echo_server/main.cpp
@@ -54,7 +54,7 @@ class Session {
     }
 
   private:
-    static constexpr size_t k_buf_sz = 1024;
+    static constexpr size_t k_buf_sz = 16 * 1024UL;
 
     std::array<uint8_t, k_buf_sz> buf_{};
     std::array<uint8_t, k_buf_sz>::iterator head_{buf_.begin()};
@@ -85,5 +85,6 @@ int main(int argc, char** argv) {
         event_loop->run();
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";
+        return -1;
     }
 }

--- a/include/axle/async_socket.h
+++ b/include/axle/async_socket.h
@@ -1,0 +1,46 @@
+#include "fiber.h"
+#include "axle/event.h"
+#include "axle/socket.h"
+
+namespace axle {
+
+class AsyncSocket {
+  public:
+    AsyncSocket();
+    explicit AsyncSocket(int fd);
+    AsyncSocket(AsyncSocket&& other) noexcept;
+    virtual ~AsyncSocket();
+
+    AsyncSocket(const AsyncSocket&) = delete;
+    AsyncSocket& operator=(const AsyncSocket&) = delete;
+    AsyncSocket& operator=(AsyncSocket&&) = delete;
+
+    Status<None, int> send_all(std::span<const uint8_t> buf_view) const;
+    Status<std::span<uint8_t>, int> recv_some(std::span<uint8_t> buf_view) const;
+    Status<None, int> close();
+
+    int get_fd() const;
+
+  protected:
+    std::shared_ptr<EventLoop> event_loop_; // NOLINT(misc-non-private-member-variables-in-classes)
+
+  private:
+    int fd_;
+};
+
+class AsyncClientSocket : public AsyncSocket {
+  public:
+    AsyncClientSocket() = default;
+
+    Status<None, int> connect(const std::string& address, int port) const;
+};
+
+class AsyncServerSocket : public AsyncSocket {
+  public:
+    AsyncServerSocket();
+
+    Status<None, int> listen(int port, int backlog) const;
+    Status<AsyncSocket, int> accept() const;
+};
+
+} // namespace axle

--- a/include/axle/event.h
+++ b/include/axle/event.h
@@ -37,6 +37,7 @@ class EventLoop {
     Status<None, None> remove_fd_eof(int fd);
     Status<None, int> remove_timer(uint64_t id);
 
+    void tick();
     void run();
 
     Status<None, int> shutdown() const;

--- a/include/axle/scheduler.h
+++ b/include/axle/scheduler.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <functional>
+#include <list>
+#include <memory>
+
+#include "fiber.h"
+#include "axle/event.h"
+
+namespace axle {
+
+class Scheduler {
+  public:
+    static void init();
+
+    static void schedule(std::function<void()> task);
+    static void yield();
+    static void resume(std::shared_ptr<Fiber> fiber);
+    static std::shared_ptr<Fiber> current_fiber();
+    static std::shared_ptr<EventLoop> get_event_loop();
+
+  private:
+    static std::unique_ptr<Scheduler> k_instance;
+
+    explicit Scheduler(std::shared_ptr<EventLoop> event_loop);
+
+    void do_schedule(std::function<void()> task);
+    void do_yield();
+    void terminate_fiber();
+    void enqueue(std::shared_ptr<Fiber> fiber);
+    void run();
+    void switch_to(std::shared_ptr<Fiber> target);
+
+    std::shared_ptr<Fiber> current_fiber_;
+    std::shared_ptr<Fiber> loop_fiber_;
+    std::shared_ptr<EventLoop> event_loop_;
+
+    std::list<std::shared_ptr<Fiber>> ready_fibers_;
+    std::list<std::shared_ptr<Fiber>> terminated_fibers_;
+};
+
+} // namespace axle

--- a/include/axle/socket.h
+++ b/include/axle/socket.h
@@ -13,11 +13,12 @@ class Socket {
   public:
     Socket();
     explicit Socket(int fd);
+    Socket& operator=(Socket&&) = delete;
+    virtual ~Socket();
+
     Socket(const Socket&) = delete;
     Socket& operator=(const Socket&) = delete;
     Socket(Socket&& other) noexcept;
-    Socket& operator=(Socket&&) = delete;
-    virtual ~Socket();
 
     Status<None, int> set_non_blocking() const;
 

--- a/src/async_socket.cpp
+++ b/src/async_socket.cpp
@@ -1,0 +1,157 @@
+#include "axle/async_socket.h"
+
+#include <cerrno>
+#include <cstdint>
+
+#include <span>
+#include <stdexcept>
+#include <utility>
+
+#include "socket_common.h"
+#include "axle/event.h"
+#include "axle/scheduler.h"
+#include "axle/status.h"
+
+namespace axle {
+
+AsyncSocket::AsyncSocket() : AsyncSocket(socket::create_tcp()) {}
+
+AsyncSocket::AsyncSocket(int fd) : event_loop_(Scheduler::get_event_loop()), fd_(fd) {
+    if (fd_ == -1) {
+        throw std::runtime_error("invalid socket fd");
+    }
+
+    if (socket::set_non_blocking(fd_).is_err()) {
+        (void)close();
+
+        throw std::runtime_error("failed to put socket in non-blocking mode");
+    }
+
+    if (socket::set_opt_nosigpipe(fd_).is_err()) {
+        (void)close();
+
+        throw std::runtime_error("could not set SO_NOSIGPIPE for socket");
+    }
+}
+
+AsyncSocket::AsyncSocket(AsyncSocket&& other) noexcept
+    : event_loop_(std::move(other.event_loop_)), fd_(other.fd_) {
+    other.fd_ = -1;
+}
+
+AsyncSocket::~AsyncSocket() {
+    (void)close();
+}
+
+Status<None, int> AsyncSocket::send_all(std::span<const uint8_t> buf_view) const {
+    while (!buf_view.empty()) {
+        Status<std::span<const uint8_t>, int> send_status = socket::send(fd_, buf_view);
+        if (send_status.is_ok()) {
+            buf_view = send_status.ok();
+            continue;
+        }
+
+        int err = send_status.err();
+        switch (err) {
+        case EWOULDBLOCK: {
+            Status<None, int> ev_status = event_loop_->register_fd_write(
+                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t>) {
+                    Scheduler::resume(fiber);
+                });
+            if (ev_status.is_err()) {
+                return Status<None, int>::make_err(ev_status.err());
+            }
+            Scheduler::yield();
+            continue;
+        }
+        default:
+            return Status<None, int>::make_err(err);
+        }
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+Status<std::span<uint8_t>, int> AsyncSocket::recv_some(std::span<uint8_t> buf_view) const {
+    for (;;) {
+        Status<std::span<uint8_t>, int> recv_status = socket::recv(fd_, buf_view);
+        if (recv_status.is_ok()) {
+            return recv_status;
+        }
+
+        int err = recv_status.err();
+        switch (err) {
+        case EWOULDBLOCK: {
+            Status<None, int> ev_status = event_loop_->register_fd_read(
+                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t>) {
+                    Scheduler::resume(fiber);
+                });
+            if (ev_status.is_err()) {
+                return Status<std::span<uint8_t>, int>::make_err(ev_status.err());
+            }
+            Scheduler::yield();
+            continue;
+        }
+        default:
+            return Status<std::span<uint8_t>, int>::make_err(err);
+        }
+    }
+}
+
+Status<None, int> AsyncSocket::close() {
+    if (event_loop_) {
+        (void)event_loop_->remove_fd_write(get_fd());
+        (void)event_loop_->remove_fd_read(get_fd());
+    }
+
+    Status<None, int> close_status = socket::close(fd_);
+    if (close_status.is_err()) {
+        return close_status;
+    }
+
+    fd_ = -1;
+
+    return Status<None, int>::make_ok();
+}
+
+int AsyncSocket::get_fd() const {
+    return fd_;
+}
+
+AsyncServerSocket::AsyncServerSocket() {
+    if (socket::set_opt_reuseaddr(get_fd()).is_err()) {
+        throw std::runtime_error("could not set SO_REUSEADDR for socket");
+    }
+}
+
+Status<None, int> AsyncServerSocket::listen(int port, int backlog) const {
+    return socket::listen(get_fd(), port, backlog);
+}
+
+Status<AsyncSocket, int> AsyncServerSocket::accept() const {
+    for (;;) {
+        Status<int, int> accept_status = socket::accept(get_fd());
+        if (accept_status.is_ok()) {
+            return Status<AsyncSocket, int>::make_ok(AsyncSocket(accept_status.ok()));
+        }
+
+        int err = accept_status.err();
+        switch (err) {
+        case EWOULDBLOCK: {
+            Status<None, int> ev_status = event_loop_->register_fd_read(
+                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t>) {
+                    Scheduler::resume(fiber);
+                });
+            if (ev_status.is_err()) {
+                return Status<AsyncSocket, int>::make_err(ev_status.err());
+            }
+            Scheduler::yield();
+            continue;
+        }
+        default:
+            return Status<AsyncSocket, int>::make_err(err);
+        }
+    }
+}
+
+} // namespace axle

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -1,0 +1,91 @@
+#include "axle/scheduler.h"
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "fiber.h"
+#include "axle/event.h"
+
+namespace axle {
+
+std::unique_ptr<Scheduler> Scheduler::k_instance = nullptr;
+
+void Scheduler::init() {
+    if (k_instance == nullptr) {
+        // Not using `std::make_unique` because `Scheduler`'s constructor is private.
+        // We don't expect to frequent create instances of this class so separating the pointer's
+        // control block from the data block is not an issue.
+        k_instance = std::unique_ptr<Scheduler>(new Scheduler(std::make_shared<EventLoop>()));
+    }
+}
+
+void Scheduler::schedule(std::function<void()> task) {
+    k_instance->do_schedule(std::move(task));
+}
+
+void Scheduler::yield() {
+    k_instance->do_yield();
+}
+
+void Scheduler::resume(std::shared_ptr<Fiber> fiber) {
+    k_instance->enqueue(std::move(fiber));
+}
+
+std::shared_ptr<Fiber> Scheduler::current_fiber() {
+    return k_instance->current_fiber_;
+}
+
+std::shared_ptr<EventLoop> Scheduler::get_event_loop() {
+    return k_instance->event_loop_;
+}
+
+Scheduler::Scheduler(std::shared_ptr<EventLoop> event_loop)
+    : current_fiber_{std::make_shared<Fiber>()},
+      loop_fiber_{std::make_shared<Fiber>([] { k_instance->run(); })},
+      event_loop_{std::move(event_loop)} {}
+
+void Scheduler::do_schedule(std::function<void()> task) {
+    std::shared_ptr<Fiber> fiber = std::make_shared<Fiber>([this, task = std::move(task)]() {
+        task();
+        Scheduler::terminate_fiber();
+    });
+    enqueue(std::move(fiber));
+}
+
+void Scheduler::do_yield() {
+    switch_to(loop_fiber_);
+}
+
+void Scheduler::terminate_fiber() {
+    terminated_fibers_.push_back(current_fiber_);
+    do_yield();
+}
+
+void Scheduler::enqueue(std::shared_ptr<Fiber> fiber) {
+    ready_fibers_.push_back(std::move(fiber));
+}
+
+void Scheduler::run() {
+    for (;;) {
+        while (!ready_fibers_.empty()) {
+            std::shared_ptr<Fiber> target = std::move(ready_fibers_.back());
+            ready_fibers_.pop_back();
+            switch_to(std::move(target));
+        }
+
+        while (!terminated_fibers_.empty()) {
+            terminated_fibers_.pop_back();
+        }
+
+        event_loop_->tick();
+    }
+}
+
+void Scheduler::switch_to(std::shared_ptr<Fiber> target) {
+    const std::shared_ptr<Fiber> source = std::move(current_fiber_);
+    current_fiber_ = std::move(target);
+    source->switch_to(current_fiber_.get());
+}
+
+} // namespace axle

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1,50 +1,30 @@
 #include "axle/socket.h"
 
-#include <fcntl.h>
-#include <unistd.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h> // IWYU pragma: keep -- for ssize_t
-
 #include <cerrno>
 #include <cstdint>
-#include <cstdio>
 
 #include <span>
 #include <stdexcept>
 #include <string>
 
+#include "socket_common.h"
 #include "axle/status.h"
-
-namespace {
-
-int do_fcntl(int fd, int cmd, int flags) {
-    return fcntl(fd, cmd, flags); // NOLINT(cppcoreguidelines-pro-type-vararg, misc-include-cleaner)
-}
-
-struct sockaddr* endpoint_to_sockaddr(const std::string& address,
-                                      int port,
-                                      struct sockaddr_in& addr_in) {
-    addr_in.sin_family = AF_INET;
-    addr_in.sin_port = htons(port); // NOLINT(misc-include-cleaner)
-    addr_in.sin_addr.s_addr = inet_addr(address.c_str());
-
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return reinterpret_cast<struct sockaddr*>(&addr_in);
-}
-
-} // namespace
 
 namespace axle {
 
-Socket::Socket() : fd_(socket(AF_INET, SOCK_STREAM, 0)) {
+Socket::Socket() : Socket(socket::create_tcp()) {}
+
+Socket::Socket(int fd) : fd_(fd) {
     if (fd_ == -1) {
-        throw std::runtime_error("failed to create client socket");
+        throw std::runtime_error("invalid socket fd");
+    }
+
+    if (socket::set_opt_nosigpipe(fd_).is_err()) {
+        (void)close();
+
+        throw std::runtime_error("could not set SO_NOSIGPIPE for socket");
     }
 }
-
-Socket::Socket(int fd) : fd_(fd) {}
 
 Socket::Socket(Socket&& other) noexcept : fd_(other.fd_) {
     other.fd_ = -1;
@@ -55,55 +35,30 @@ Socket::~Socket() {
 }
 
 Status<None, int> Socket::set_non_blocking() const {
-    const int flags = do_fcntl(fd_, F_GETFL, 0); // NOLINT(misc-include-cleaner) -- for F_GETFL
-    if (flags == -1) {
-        perror("failed to get socket flags");
-
-        return Status<None, int>::make_err(errno);
-    }
-
-    // NOLINTNEXTLINE(misc-include-cleaner) -- for F_SETFL, O_NONBLOCK
-    if (do_fcntl(fd_, F_SETFL, flags | O_NONBLOCK) == -1) {
-        perror("failed to put socket in non-blocking mode");
-
-        return Status<None, int>::make_err(errno);
-    }
-
-    return Status<None, int>::make_ok();
+    return socket::set_non_blocking(fd_);
 }
 
 Status<None, int> Socket::send_all(std::span<const uint8_t> buf) const {
     while (!buf.empty()) {
-        // NOLINTNEXTLINE(misc-include-cleaner) -- for ssize_t
-        const ssize_t len = write(fd_, buf.data(), buf.size());
-        if (len == -1) {
-            perror("failed to write to socket");
-
-            return Status<None, int>::make_err(errno);
+        Status<std::span<const uint8_t>, int> send_status = socket::send(fd_, buf);
+        if (send_status.is_err()) {
+            return Status<None, int>::make_err(send_status.err());
         }
-        buf = buf.subspan(len);
+
+        buf = send_status.ok();
     }
 
     return Status<None, int>::make_ok();
 }
 
-Status<std::span<uint8_t>, int> Socket::recv_some(std::span<uint8_t> buf_view) const {
-    const ssize_t len = read(fd_, buf_view.data(), buf_view.size());
-    if (len == -1) {
-        perror("failed to read from connection");
-
-        return Status<std::span<uint8_t>, int>::make_err(errno);
-    }
-
-    return Status<std::span<uint8_t>, int>::make_ok(buf_view.first(len));
+Status<std::span<uint8_t>, int> Socket::recv_some(std::span<uint8_t> buf) const {
+    return socket::recv(fd_, buf);
 }
 
 Status<None, int> Socket::close() {
-    const int fd = fd_;
-    if (fd != -1 && ::close(fd) == -1) {
-        perror("failed to close socket fd");
-
-        return Status<None, int>::make_err(errno);
+    Status<None, int> close_status = socket::close(fd_);
+    if (close_status.is_err()) {
+        return close_status;
     }
 
     fd_ = -1;
@@ -116,52 +71,26 @@ int Socket::get_fd() const {
 }
 
 Status<None, int> ClientSocket::connect(const std::string& address, int port) const {
-    struct sockaddr_in addr_in{};
-    struct sockaddr* addr = endpoint_to_sockaddr(address, port, addr_in);
-
-    if (::connect(get_fd(), addr, sizeof(*addr)) == -1) {
-        perror("failed to connect to server");
-
-        return Status<None, int>::make_err(errno);
-    }
-
-    return Status<None, int>::make_ok();
+    return socket::connect(get_fd(), address, port);
 }
 
 ServerSocket::ServerSocket() {
-    int enable = 1;
-    if (setsockopt(get_fd(), SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) == -1) {
-        throw std::runtime_error("failed to create client socket");
+    if (socket::set_opt_reuseaddr(get_fd()).is_err()) {
+        throw std::runtime_error("could not set SO_REUSEADDR for socket");
     }
 }
 
 Status<None, int> ServerSocket::listen(int port, int backlog) const {
-    struct sockaddr_in addr_in{};
-    struct sockaddr* addr = endpoint_to_sockaddr("0.0.0.0", port, addr_in);
-    if (bind(get_fd(), addr, sizeof(*addr)) == -1) {
-        perror("failed to bind to socket");
-
-        return Status<None, int>::make_err(errno);
-    }
-
-    if (::listen(get_fd(), backlog) < 0) {
-        perror("failed to listen for incoming connections");
-
-        return Status<None, int>::make_err(errno);
-    }
-
-    return Status<None, int>::make_ok();
+    return socket::listen(get_fd(), port, backlog);
 }
 
 Status<Socket, int> ServerSocket::accept() const {
-    const int peer_fd = ::accept(get_fd(), nullptr, nullptr);
-    if (peer_fd == -1) {
-        perror("failed to accept connection");
-
-        return Status<Socket, int>::make_err(errno);
+    Status<int, int> accept_status = socket::accept(get_fd());
+    if (accept_status.is_err()) {
+        return Status<Socket, int>::make_err(accept_status.err());
     }
 
-    return Status<Socket, int>::make_ok(Socket(peer_fd));
+    return Status<Socket, int>::make_ok(Socket(accept_status.ok()));
 }
 
 } // namespace axle

--- a/src/socket_common.h
+++ b/src/socket_common.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/types.h>
+
+static int do_fcntl(int fd, int cmd, int flags) {
+    return fcntl(fd, cmd, flags); // NOLINT(cppcoreguidelines-pro-type-vararg, misc-include-cleaner)
+}
+
+static struct sockaddr* endpoint_to_sockaddr(const std::string& address,
+                                             int port,
+                                             struct sockaddr_in& addr_in) {
+    addr_in.sin_family = AF_INET;
+    addr_in.sin_port = htons(port); // NOLINT(misc-include-cleaner)
+    addr_in.sin_addr.s_addr = inet_addr(address.c_str());
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<struct sockaddr*>(&addr_in);
+}
+
+static axle::Status<axle::None, int> do_setsockopt(const int fd, int opt) {
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, opt, &enable, sizeof(enable)) == -1) {
+        return axle::Status<axle::None, int>::make_err(errno);
+    }
+
+    return axle::Status<axle::None, int>::make_ok();
+}
+
+namespace axle::socket {
+
+inline int create_tcp() {
+    return ::socket(AF_INET, SOCK_STREAM, 0);
+}
+
+inline Status<None, int> set_non_blocking(const int fd) {
+    const int flags = do_fcntl(fd, F_GETFL, 0); // NOLINT(misc-include-cleaner) -- for F_GETFL
+    if (flags == -1) {
+        return Status<None, int>::make_err(errno);
+    }
+
+    // NOLINTNEXTLINE(misc-include-cleaner) -- for F_SETFL, O_NONBLOCK
+    if (do_fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+inline Status<None, int> set_opt_nosigpipe(const int fd) {
+    return do_setsockopt(fd, SO_NOSIGPIPE);
+}
+
+inline Status<None, int> set_opt_reuseaddr(const int fd) {
+    return do_setsockopt(fd, SO_REUSEADDR);
+}
+
+inline Status<std::span<const uint8_t>, int> send(const int fd,
+                                                  const std::span<const uint8_t> buf) {
+    // NOLINTNEXTLINE(misc-include-cleaner) -- for ssize_t
+    const ssize_t len = write(fd, buf.data(), buf.size());
+    if (len == -1) {
+        return Status<std::span<const uint8_t>, int>::make_err(errno);
+    }
+
+    return Status<std::span<const uint8_t>, int>::make_ok(buf.subspan(len));
+}
+
+inline Status<std::span<uint8_t>, int> recv(const int fd, const std::span<uint8_t> buf) {
+    const ssize_t len = read(fd, buf.data(), buf.size());
+    if (len == -1) {
+        return Status<std::span<uint8_t>, int>::make_err(errno);
+    }
+
+    return Status<std::span<uint8_t>, int>::make_ok(buf.first(len));
+}
+
+inline Status<None, int> listen(const int fd, const int port, const int backlog) {
+    struct sockaddr_in addr_in{};
+    struct sockaddr* addr = endpoint_to_sockaddr("0.0.0.0", port, addr_in);
+    if (bind(fd, addr, sizeof(*addr)) == -1) {
+        return Status<None, int>::make_err(errno);
+    }
+
+    if (::listen(fd, backlog) < 0) {
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+inline Status<int, int> accept(const int fd) {
+    const int peer_fd = ::accept(fd, nullptr, nullptr);
+    if (peer_fd == -1) {
+        return Status<int, int>::make_err(errno);
+    }
+
+    return Status<int, int>::make_ok(peer_fd);
+}
+
+inline Status<None, int> connect(const int fd, const std::string& address, const int port) {
+    struct sockaddr_in addr_in{};
+    struct sockaddr* addr = endpoint_to_sockaddr(address, port, addr_in);
+
+    if (::connect(fd, addr, sizeof(*addr)) == -1) {
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+inline Status<None, int> close(const int fd) {
+    if (fd != -1 && ::close(fd) == -1) {
+        return Status<None, int>::make_err(errno);
+    }
+
+    return Status<None, int>::make_ok();
+}
+
+} // namespace axle::socket


### PR DESCRIPTION
This is a first-cut implementation of a fiber scheduler is meant to be used with `EventLoop` to provide fiber-based networking primitives. Typical usage entails:
1- Attempting a socket read/write.
2- Registering a filter with `EventLoop` in case the operation is going to block. The callback resumes the fiber to attempt the IO again.
3- Yield to the scheduler.

The scheduler will first make progress on "ready" fibers. Otherwise, it will block until `EventLoop` resumes any fibers.

Outstanding work remains:
1- Improve the way filters are (de)registered with `EventLoop`.
2- Eliminate any potential memory leak.
3- Add tests everywhere since the only test right now is an example echo server.