### PR TITLE
Run sanitizer builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,10 @@ jobs:
       matrix:
         os: [ macos-latest ]
         build_type:
-          - -DENABLE_MSAN=ON
-          - -DENABLE_UBSAN=ON
+          - -DAXLE_ENABLE_MSAN=ON -DCMAKE_BUILD_TYPE=Release
+          - -DAXLE_ENABLE_UBSAN=ON -DCMAKE_BUILD_TYPE=Release
           - -DCMAKE_BUILD_TYPE=Release
+          - -DCMAKE_BUILD_TYPE=Debug
 
     steps:
     - uses: actions/checkout@v2
@@ -65,7 +66,7 @@ jobs:
       run: ./tools/install-deps.sh
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build ${{ matrix.build_options }} -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++
+      run: cmake -B ${{github.workspace}}/build ${{ matrix.build_type }} -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,14 +40,17 @@ if(ENABLE_MSAN)
         )
         add_link_options(-fsanitize=memory)
     endif()
-endif()
 
-if(ENABLE_UBSAN)
+    message("MSAN enabled")
+elseif(ENABLE_UBSAN)
     add_compile_options(
         -fsanitize=undefined
         -g
     )
     add_link_options(-fsanitize=undefined)
+    message("UBSAN enabled")
+else()
+    message("No sanitizers enabled")
 endif()
 
 # Dependencies


### PR DESCRIPTION
Because they weren't really running due to an environment variable mismatch: build_option vs build_type.

Also, run them in "Release" mode.