### PR TITLE
Introduce Scheduler termination

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,27 +24,27 @@ IncludeIsMainRegex: "(_test)?$"
 IncludeBlocks: Regroup
 SortIncludes: true
 IncludeCategories:
-  - Regex:           '^<[a-z]+\.h>'             # <unistd.h>
+  - Regex:           '^<[a-z]+\.h>'                    # <unistd.h>
     Priority:        1
     SortPriority:    1
-  - Regex:           '^<[a-z]+/.*\.h>'          # <sys/event.h>
+  - Regex:           '^<[a-z]+/.*\.h>'                 # <sys/event.h>
     SortPriority:    2
     Priority:        1
-  - Regex:           '^<c(errno|string|std).*>' # <cstring>
+  - Regex:           '^<c(errno|signal|string|std).*>' # <cstring>
     Priority:        2
     SortPriority:    3
-  - Regex:           '^<.*/'                    # <a/other>
+  - Regex:           '^<.*/'                           # <a/other>
     Priority:        3
     SortPriority:    5
-  - Regex:           '^<[^/]*>'                 # <other>
+  - Regex:           '^<[^/]*>'                        # <other>
     Priority:        3
     SortPriority:    4
-  - Regex:           '^"gtest/.*"'              # "gtest/gtest.h"
+  - Regex:           '^"gtest/.*"'                     # "gtest/gtest.h"
     SortPriority:    8
     Priority:        5
-  - Regex:           '^".*/'                    # "b/project"
+  - Regex:           '^".*/'                           # "b/project"
     SortPriority:    7
     Priority:        4
-  - Regex:           '^".*"'                    # "project"
+  - Regex:           '^".*"'                           # "project"
     SortPriority:    6
     Priority:        4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,10 @@ Checks: >
   readability-*,
   -bugprone-easily-swappable-parameters,
   -readability-identifier-length,
-  -cppcoreguidelines-non-private-member-variables-in-classes
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-macro-usage
 
 HeaderFilterRegex: "(src|include)/.*"
 WarningsAsErrors: "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [ macos-latest ]
         build_type:
-          - -DAXLE_ENABLE_MSAN=ON -DCMAKE_BUILD_TYPE=Release
+          - -DAXLE_ENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Release
           - -DAXLE_ENABLE_UBSAN=ON -DCMAKE_BUILD_TYPE=Release
           - -DCMAKE_BUILD_TYPE=Release
           - -DCMAKE_BUILD_TYPE=Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,27 +22,18 @@ add_compile_options(
     -Werror
 )
 
-option(AXLE_ENABLE_MSAN "Enable Memory Sanitizer" OFF)
-option(AXLE_ENABLE_USAN "Enable Undefined Behavior Sanitizer" OFF)
+option(AXLE_ENABLE_ASAN "Enable Address Sanitizer" OFF)
+option(AXLE_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 
-if(AXLE_ENABLE_MSAN)
-    if(APPLE)
-        add_compile_options(
-            -fsanitize=address
-            -fno-omit-frame-pointer
-            -g
-        )
-        add_link_options(-fsanitize=address)
-    else()
-        add_compile_options(
-            -fsanitize=memory
-            -fno-omit-frame-pointer
-            -g
-        )
-        add_link_options(-fsanitize=memory)
-    endif()
-    message("MSAN enabled")
-elseif(AXLE_ENABLE_UBSAN)
+if(AXLE_ENABLE_ASAN)
+    add_compile_options(
+        -fsanitize=address
+        -fno-omit-frame-pointer
+        -g
+    )
+    add_link_options(-fsanitize=address)
+    message("ASAN enabled")
+elseif(AXLE_UBSAN_ENABLED)
     add_compile_options(
         -fsanitize=undefined
         -g
@@ -101,20 +92,27 @@ set(AXLE_TEST_LIST
 add_library(axle-lib ${AXLE_SRC_LIST})
 target_include_directories(axle-lib PUBLIC ${AXLE_INCLUDE_DIR} ${AXLE_SRC_DIR})
 set_target_properties(axle-lib PROPERTIES OUTPUT_NAME axle)
+if (AXLE_ENABLE_ASAN)
+    target_compile_definitions(axle-lib PUBLIC "AXLE_ASAN_ENABLED=1")
+endif()
 
 add_executable(axle-tests ${AXLE_TEST_LIST})
 target_include_directories(axle-tests PRIVATE ${AXLE_SRC_DIR})
 target_link_libraries(axle-tests axle-lib gtest_main)
 
 add_test(unit-tests axle-tests)
-if(AXLE_ENABLE_MSAN)
+if(AXLE_ENABLE_ASAN)
     if(APPLE)
-        set_tests_properties(unit-tests PROPERTIES
-            ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/sanitizers/asan/asan_leak_supp_darwin_arm64.txt"
-        )
+        set(AXLE_ASAN_OPTIONS detect_leaks=1)
     endif()
+    set(AXLE_LSAN_SUPP_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
+    )
+    set(AXLE_LSAN_OPTIONS suppressions=${AXLE_LSAN_SUPP_FILE})
+    set_tests_properties(unit-tests PROPERTIES
+        ENVIRONMENT "ASAN_OPTIONS=${AXLE_ASAN_OPTIONS};LSAN_OPTIONS=${AXLE_LSAN_OPTIONS}"
+    )
 endif()
-
 
 add_executable(echo_server ${AXLE_EXAMPLES_DIR}/echo_server/main.cpp)
 target_link_libraries(echo_server axle-lib)

--- a/examples/async_echo_server/main.cpp
+++ b/examples/async_echo_server/main.cpp
@@ -1,3 +1,7 @@
+#include <signal.h>
+
+#include <cerrno>
+#include <csignal>
 #include <cstddef>
 #include <cstdint>
 
@@ -40,36 +44,56 @@ void connection_handler(const std::shared_ptr<axle::AsyncSocket>& socket) {
     }
 }
 
+volatile sig_atomic_t done = 0;
+
+void server_loop(int port, int backlog) {
+    const axle::AsyncServerSocket socket{};
+    axle::Status<axle::None, int> listen_status = socket.listen(port, backlog);
+    if (listen_status.is_err()) {
+        std::cerr << "could not listen on socket - error: " << listen_status.err() << "\n";
+        return;
+    }
+
+    std::cerr << "Echo server launched on 127.0.0.1:" << port << "\n";
+
+    while (done != 1) {
+        axle::Status<axle::AsyncSocket, int> accept_status = socket.accept();
+        if (accept_status.is_err()) {
+            std::cerr << "could not accept connection - error: " << accept_status.err() << "\n";
+            return;
+        }
+
+        std::shared_ptr<axle::AsyncSocket> peer_socket =
+            std::make_shared<axle::AsyncSocket>(accept_status.ok());
+
+        axle::Scheduler::schedule([s = std::move(peer_socket)]() { connection_handler(s); });
+    }
+}
+
+void signal_handler(int signal) {
+    (void)signal;
+
+    done = 1;
+    axle::Scheduler::terminate();
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
     (void)argc;
     (void)argv;
 
-    constexpr int port = 8080;
-    constexpr int backlog = 128;
-    axle::Scheduler::init();
+    if (signal(SIGINT, signal_handler) != 0) {
+        std::cerr << "failed to register signal handler - error: " << errno << "\n";
+        return -1;
+    }
 
     try {
-        const axle::AsyncServerSocket socket{};
-        axle::Status<axle::None, int> listen_status = socket.listen(port, backlog);
-        if (listen_status.is_err()) {
-            std::cerr << "could not listen on socket - error: " << listen_status.err() << "\n";
-            return -1;
-        }
-
-        for (;;) {
-            axle::Status<axle::AsyncSocket, int> accept_status = socket.accept();
-            if (accept_status.is_err()) {
-                std::cerr << "could not accept connection - error: " << accept_status.err() << "\n";
-                return -1;
-            }
-
-            std::shared_ptr<axle::AsyncSocket> peer_socket =
-                std::make_shared<axle::AsyncSocket>(accept_status.ok());
-
-            axle::Scheduler::schedule([s = std::move(peer_socket)]() { connection_handler(s); });
-        }
+        constexpr int port = 8080;
+        constexpr int backlog = 128;
+        axle::Scheduler::init();
+        axle::Scheduler::schedule([] { server_loop(port, backlog); });
+        axle::Scheduler::yield();
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";
         return -1;

--- a/include/axle/scheduler.h
+++ b/include/axle/scheduler.h
@@ -12,6 +12,7 @@ namespace axle {
 class Scheduler {
   public:
     static void init();
+    static void terminate();
 
     static void schedule(std::function<void()> task);
     static void yield();
@@ -31,12 +32,15 @@ class Scheduler {
     void run();
     void switch_to(std::shared_ptr<Fiber> target);
 
-    std::shared_ptr<Fiber> current_fiber_;
+    std::shared_ptr<Fiber> main_fiber_;
     std::shared_ptr<Fiber> loop_fiber_;
+    std::shared_ptr<Fiber> current_fiber_;
     std::shared_ptr<EventLoop> event_loop_;
 
     std::list<std::shared_ptr<Fiber>> ready_fibers_;
     std::list<std::shared_ptr<Fiber>> terminated_fibers_;
+
+    bool done_ = false;
 };
 
 } // namespace axle

--- a/src/fiber.h
+++ b/src/fiber.h
@@ -7,6 +7,7 @@
 #include <functional>
 
 #include "fiber_arm64.h"
+#include "sanitizer.h"
 
 namespace axle {
 
@@ -14,15 +15,22 @@ class Fiber {
   public:
     Fiber() = default;
     explicit Fiber(std::function<void()> func);
-    void switch_to(const Fiber* other);
+
+    void switch_to(Fiber* target);
+    void interrupt();
+    bool interrupted();
 
   private:
-    static void run_func(void* fiber_handle);
     static constexpr size_t k_stack_sz = 32 * 1024UL;
+
+    static void run_func(void* fiber_handle);
 
     std::function<void()> func_;
     FiberCtx ctx_{};
     std::array<uint8_t, k_stack_sz> stack_{};
+    bool interrupted_{false};
+
+    AXLE_ASAN_CTX_DECLARE();
 };
 
 } // namespace axle

--- a/src/sanitizer.h
+++ b/src/sanitizer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#if AXLE_ASAN_ENABLED
+
+#include <sanitizer/common_interface_defs.h>
+
+#define AXLE_ASAN_CTX_DECLARE()                                                                    \
+    struct ASanCtx {                                                                               \
+        Fiber* from;                                                                               \
+        void* stack_base;                                                                          \
+        size_t stack_sz;                                                                           \
+    };                                                                                             \
+    ASanCtx asan_ctx_ {}
+
+#define AXLE_ASAN_CTX_INIT(stack_base__, stack_sz__)                                               \
+    do {                                                                                           \
+        asan_ctx_.stack_base = (void*)(stack_base__);                                              \
+        asan_ctx_.stack_sz = (stack_sz__);                                                         \
+    } while (0)
+
+#define AXLE_ASAN_START_SWITCH_FIBER(from__, to__)                                                 \
+    do {                                                                                           \
+        ASanCtx* asan_ctx__ = &(to__)->asan_ctx_;                                                  \
+        asan_ctx__->from = from__;                                                                 \
+        __sanitizer_start_switch_fiber(nullptr, asan_ctx__->stack_base, asan_ctx__->stack_sz);     \
+    } while (0)
+
+#define AXLE_ASAN_FINISH_SWITCH_FIBER(to__)                                                        \
+    do {                                                                                           \
+        ASanCtx* asan_ctx__ = &(to__)->asan_ctx_.from->asan_ctx_;                                  \
+        __sanitizer_finish_switch_fiber(                                                           \
+            nullptr, (const void**)&asan_ctx__->stack_base, &asan_ctx__->stack_sz);                \
+    } while (0)
+
+#else
+
+#define AXLE_ASAN_CTX_DECLARE() static_assert(true) // NOLINT()
+#define AXLE_ASAN_CTX_INIT(stack_base__, stack_sz__)
+#define AXLE_ASAN_START_SWITCH_FIBER(from__, to__)
+#define AXLE_ASAN_FINISH_SWITCH_FIBER(to__)
+
+#endif // AXLE_ASAN_ENABLED

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -20,6 +20,10 @@ void Scheduler::init() {
     }
 }
 
+void Scheduler::terminate() {
+    k_instance->done_ = true;
+}
+
 void Scheduler::schedule(std::function<void()> task) {
     k_instance->do_schedule(std::move(task));
 }
@@ -41,8 +45,9 @@ std::shared_ptr<EventLoop> Scheduler::get_event_loop() {
 }
 
 Scheduler::Scheduler(std::shared_ptr<EventLoop> event_loop)
-    : current_fiber_{std::make_shared<Fiber>()},
+    : main_fiber_{std::make_shared<Fiber>()},
       loop_fiber_{std::make_shared<Fiber>([] { k_instance->run(); })},
+      current_fiber_{main_fiber_},
       event_loop_{std::move(event_loop)} {}
 
 void Scheduler::do_schedule(std::function<void()> task) {
@@ -78,13 +83,20 @@ void Scheduler::run() {
             terminated_fibers_.pop_back();
         }
 
+        if (done_) {
+            switch_to(main_fiber_);
+        }
+
         event_loop_->tick();
     }
 }
 
 void Scheduler::switch_to(std::shared_ptr<Fiber> target) {
-    const std::shared_ptr<Fiber> source = std::move(current_fiber_);
+    // We use a raw pointer instead of a `std::shared_ptr` to avoid leaking memory.
+    // A `std::shared_ptr` will drop ref-count only if it goes out of scope, ...
+    Fiber* source = current_fiber_.get();
     current_fiber_ = std::move(target);
+    // ... which is not guaranteed to happen becuase the next line might not return
     source->switch_to(current_fiber_.get());
 }
 

--- a/test/fiber_test.cpp
+++ b/test/fiber_test.cpp
@@ -28,7 +28,7 @@ TEST(Fibers, ExitFromFiber) {
     Fiber main_fiber{};
     int a = 1;
 
-    const Fiber fiber1{[&] {
+    Fiber fiber1{[&] {
         EXPECT_EQ(1, a);
         a = 2;
         return;


### PR DESCRIPTION
This is a signal-based mechanism that integrates with both `EventLoop`
and `Fiber`. It is expected that the application installs a signal
handler that eventually calls `Scheduler::terminate`. The signal sent
also interrupts the `EventLoop` if it's waiting on the kernel for
events.  Any blocked fibers will be interrupted, and it is the
responsibility of the async primitives to handle the interruption event.

The interruption mechanism helped uncover a leak in `Scheduler`. I
noticed that not all `Fiber` instances were cleaned up (destructor
wasn't being called) and it turns out that ASan support was incomplete:
there is a need to call fiber-specific hooks that keep track of the
stack across context switches. The erroneous code generates the
following leak report when running the example async_echo_server.

```
async_echo_server(5531,0x200658240) malloc: nano zone abandoned due to inability to reserve vm space.
Echo server launched on 127.0.0.1:8080
^Ccould not accept connection - error: 4

=================================================================
==5531==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 33064 byte(s) in 1 object(s) allocated from:
    #0 0x0001055ba370 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62370)
    #1 0x000104ec2aec in axle::Scheduler::Scheduler(std::__1::shared_ptr<axle::EventLoop>) scheduler.cpp:49
    #2 0x000104ec119c in axle::Scheduler::init() scheduler.cpp:19
    #3 0x000104eafb60 in main main.cpp:94
    #4 0x0001969f8270  (<unknown module>)

Indirect leak of 33064 byte(s) in 1 object(s) allocated from:
    #0 0x0001055ba370 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62370)
    #1 0x000104ec17dc in axle::Scheduler::do_schedule(std::__1::function<void ()>) scheduler.cpp:55
    #2 0x000104ec147c in axle::Scheduler::schedule(std::__1::function<void ()>) scheduler.cpp:28
    #3 0x000104eafb8c in main main.cpp:95
    #4 0x0001969f8270  (<unknown module>)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x0001055ba370 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x62370)
    #1 0x000104ec18b4 in axle::Scheduler::do_schedule(std::__1::function<void ()>) scheduler.cpp:55
    #2 0x000104ec147c in axle::Scheduler::schedule(std::__1::function<void ()>) scheduler.cpp:28
    #3 0x000104eafb8c in main main.cpp:95
    #4 0x0001969f8270  (<unknown module>)

-----------------------------------------------------
Suppressions used:
  count      bytes template
      3        120 *_fetchInitializingClassList
-----------------------------------------------------
```
