### PR TITLE
Make Scheduler instances thread local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(AXLE_ENABLE_ASAN)
     )
     add_link_options(-fsanitize=address)
     message("ASAN enabled")
-elseif(AXLE_UBSAN_ENABLED)
+elseif(AXLE_ENABLE_UBSAN)
     add_compile_options(
         -fsanitize=undefined
         -g
@@ -86,6 +86,7 @@ set(AXLE_TEST_LIST
     ${AXLE_TEST_DIR}/axle_test.cpp
     ${AXLE_TEST_DIR}/event_test.cpp
     ${AXLE_TEST_DIR}/fiber_test.cpp
+    ${AXLE_TEST_DIR}/scheduler_test.cpp
     ${AXLE_TEST_DIR}/status_test.cpp
 )
 

--- a/examples/async_echo_server/main.cpp
+++ b/examples/async_echo_server/main.cpp
@@ -74,7 +74,7 @@ void signal_handler(int signal) {
     (void)signal;
 
     done = 1;
-    axle::Scheduler::terminate();
+    axle::Scheduler::stop();
 }
 
 } // namespace
@@ -94,6 +94,7 @@ int main(int argc, char** argv) {
         axle::Scheduler::init();
         axle::Scheduler::schedule([] { server_loop(port, backlog); });
         axle::Scheduler::yield();
+        axle::Scheduler::fini();
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";
         return -1;

--- a/include/axle/scheduler.h
+++ b/include/axle/scheduler.h
@@ -12,7 +12,8 @@ namespace axle {
 class Scheduler {
   public:
     static void init();
-    static void terminate();
+    static void stop();
+    static void fini();
 
     static void schedule(std::function<void()> task);
     static void yield();
@@ -21,7 +22,7 @@ class Scheduler {
     static std::shared_ptr<EventLoop> get_event_loop();
 
   private:
-    static std::unique_ptr<Scheduler> k_instance;
+    thread_local static std::unique_ptr<Scheduler> k_instance;
 
     explicit Scheduler(std::shared_ptr<EventLoop> event_loop);
 

--- a/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
+++ b/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
@@ -1,1 +1,3 @@
 leak:*_fetchInitializingClassList
+leak:*tlv_get_addr
+leak:*thread-local wrapper routine

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -9,7 +9,7 @@
 
 namespace axle {
 
-std::unique_ptr<Scheduler> Scheduler::k_instance = nullptr;
+thread_local std::unique_ptr<Scheduler> Scheduler::k_instance = nullptr;
 
 void Scheduler::init() {
     if (k_instance == nullptr) {
@@ -20,8 +20,12 @@ void Scheduler::init() {
     }
 }
 
-void Scheduler::terminate() {
+void Scheduler::stop() {
     k_instance->done_ = true;
+}
+
+void Scheduler::fini() {
+    k_instance = nullptr;
 }
 
 void Scheduler::schedule(std::function<void()> task) {

--- a/test/fiber_test.cpp
+++ b/test/fiber_test.cpp
@@ -6,7 +6,7 @@
 
 namespace axle {
 
-TEST(Fibers, PingPong) {
+TEST(FiberTest, PingPong) {
     Fiber main_fiber{};
     int a = 0;
     Fiber other_fiber{[&] {
@@ -24,7 +24,7 @@ TEST(Fibers, PingPong) {
     EXPECT_EQ(3, a);
 }
 
-TEST(Fibers, ExitFromFiber) {
+TEST(FiberTest, ExitFromFiber) {
     Fiber main_fiber{};
     int a = 1;
 
@@ -37,7 +37,7 @@ TEST(Fibers, ExitFromFiber) {
     EXPECT_EXIT(main_fiber.switch_to(&fiber1), testing::ExitedWithCode(0x19), "");
 }
 
-TEST(Fibers, Chain) {
+TEST(FiberTest, Chain) {
     Fiber main_fiber{};
     int a = 0;
     Fiber fiber2{[&] {
@@ -51,6 +51,16 @@ TEST(Fibers, Chain) {
     }};
     main_fiber.switch_to(&fiber1);
     EXPECT_EQ(2, a);
+}
+
+TEST(FiberTest, Interrupt) {
+    Fiber fiber{};
+    ASSERT_FALSE(fiber.interrupted());
+
+    fiber.interrupt();
+    ASSERT_TRUE(fiber.interrupted());
+    // Fiber::interrupted resets the interrupt state
+    ASSERT_FALSE(fiber.interrupted());
 }
 
 } // namespace axle

--- a/test/scheduler_test.cpp
+++ b/test/scheduler_test.cpp
@@ -1,0 +1,99 @@
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+#include "axle/scheduler.h"
+
+#include <thread>
+
+#include "gtest/gtest.h"
+
+namespace axle {
+
+TEST(SchedulerTest, RunTasks) {
+    int a = 0;
+    Scheduler::init();
+
+    Scheduler::schedule([&] { a += 1; });
+
+    Scheduler::schedule([&] { a += 2; });
+
+    Scheduler::stop();
+    Scheduler::yield();
+    Scheduler::fini();
+
+    ASSERT_EQ(3, a);
+}
+
+TEST(SchedulerTest, NoInit) {
+    ASSERT_DEATH(Scheduler::schedule([] {}), "");
+}
+
+TEST(SchedulerTest, NestedScheduling) {
+    int a = 0;
+    Scheduler::init();
+
+    Scheduler::schedule([&] {
+        a++;
+        Scheduler::schedule([&a] { a++; });
+    });
+
+    Scheduler::stop();
+    Scheduler::yield();
+    Scheduler::fini();
+
+    ASSERT_EQ(2, a);
+}
+
+TEST(SchedulerTest, ManyTasks) {
+    constexpr int task_cnt = 10000;
+    int a = 0;
+    Scheduler::init();
+
+    for (int i = 0; i < task_cnt; ++i) {
+        Scheduler::schedule([&] { a++; });
+    }
+
+    Scheduler::stop();
+    Scheduler::yield();
+    Scheduler::fini();
+
+    ASSERT_EQ(task_cnt, a);
+}
+
+TEST(SchedulerTest, Multithreaded) {
+    constexpr int task_cnt_a = 10000;
+    constexpr int task_cnt_b = 5000;
+    int a = 0;
+    int b = 0;
+
+    std::thread thread_a = std::thread([&] {
+        Scheduler::init();
+        for (int i = 0; i < task_cnt_a; ++i) {
+            Scheduler::schedule([&] { a++; });
+        }
+
+        Scheduler::stop();
+        Scheduler::yield();
+        Scheduler::fini();
+    });
+
+    std::thread thread_b = std::thread([&] {
+        Scheduler::init();
+        for (int i = 0; i < task_cnt_b; ++i) {
+            Scheduler::schedule([&] { b++; });
+        }
+
+        Scheduler::stop();
+        Scheduler::yield();
+        Scheduler::fini();
+    });
+
+    thread_a.join();
+    thread_b.join();
+
+    ASSERT_EQ(task_cnt_a, a);
+    ASSERT_EQ(task_cnt_b, b);
+}
+
+} // namespace axle
+
+// NOLINTEND(readability-function-cognitive-complexity)


### PR DESCRIPTION
Minimal work that allows init'ing a `Scheduler` instance per thread.
There is no inter-`Scheduler` communication at the moment.

Also, adds some tests to improve coverage. The `Socket` classes need
better coverage so that will come next.
