### PR TITLE
Add TSan support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
         build_type:
           - -DAXLE_ENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Release
           - -DAXLE_ENABLE_UBSAN=ON -DCMAKE_BUILD_TYPE=Release
+          - -DAXLE_ENABLE_TSAN=ON -DCMAKE_BUILD_TYPE=Release
           - -DCMAKE_BUILD_TYPE=Release
           - -DCMAKE_BUILD_TYPE=Debug
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,21 @@ if(AXLE_ENABLE_ASAN)
         -g
     )
     add_link_options(-fsanitize=address)
-    message("ASAN enabled")
+    message("ASan enabled")
 elseif(AXLE_ENABLE_UBSAN)
     add_compile_options(
         -fsanitize=undefined
         -g
     )
     add_link_options(-fsanitize=undefined)
-    message("UBSAN enabled")
+    message("UBSan enabled")
+elseif(AXLE_ENABLE_TSAN)
+    add_compile_options(
+        -fsanitize=thread
+        -g
+    )
+    add_link_options(-fsanitize=thread)
+    message("TSan enabled")
 else()
     message("No sanitizers enabled")
 endif()
@@ -104,6 +111,10 @@ add_library(axle ${AXLE_SRC_LIST})
 target_include_directories(axle PUBLIC ${AXLE_INCLUDE_DIR} PRIVATE ${AXLE_SRC_DIR})
 if (AXLE_ENABLE_ASAN)
     target_compile_definitions(axle PUBLIC "AXLE_ASAN_ENABLED=1")
+endif()
+
+if (AXLE_ENABLE_TSAN)
+    target_compile_definitions(axle PUBLIC "AXLE_TSAN_ENABLED=1")
 endif()
 
 # Unit tests

--- a/src/fiber.h
+++ b/src/fiber.h
@@ -13,8 +13,13 @@ namespace axle {
 
 class Fiber {
   public:
-    Fiber() = default;
+    Fiber();
     explicit Fiber(std::function<void()> func);
+    Fiber(const Fiber&) = delete;
+    Fiber& operator=(const Fiber&) = delete;
+    Fiber(Fiber&&) = delete;
+    Fiber& operator=(Fiber&&) = delete;
+    ~Fiber();
 
     void switch_to(Fiber* target);
     void interrupt();
@@ -31,6 +36,7 @@ class Fiber {
     bool interrupted_{false};
 
     AXLE_ASAN_CTX_DECLARE();
+    AXLE_TSAN_CTX_DECLARE();
 };
 
 } // namespace axle

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -27,7 +27,6 @@ void Scheduler::init() {
             std::unique_ptr<Scheduler> scheduler(
                 new Scheduler(std::make_shared<EventLoop>(), host_thread));
             (void)k_schedulers.emplace(host_thread, std::move(scheduler));
-
             k_instance = k_schedulers.at(host_thread).get();
         }
     }
@@ -54,6 +53,7 @@ void Scheduler::shutdown() {
 }
 
 void Scheduler::shutdown_all() {
+    const std::lock_guard<std::mutex> lk{k_schedulers_mtx};
     for (auto&& [_, scheduler] : k_schedulers) {
         scheduler->do_shutdown();
     }


### PR DESCRIPTION
The added support uncovered a race condition involving the methods `Scheduler::shutdown_all` and `Scheduler::fini`, which is now resolved.