### PR TITLE
scheduler: Eliminate run loop fiber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 build*/
 .cache/
+
+compile_commands.json

--- a/bench/async_echo_server.cpp
+++ b/bench/async_echo_server.cpp
@@ -97,7 +97,7 @@ struct BenchEchoServer {
         std::thread server_thread([&server] {
             axle::Scheduler::init();
             axle::Scheduler::schedule([&server] { server.start(); });
-            axle::Scheduler::yield();
+            axle::Scheduler::run();
             axle::Scheduler::fini();
         });
 

--- a/examples/async_echo_server/main.cpp
+++ b/examples/async_echo_server/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
         constexpr int backlog = 128;
         axle::Scheduler::init();
         axle::Scheduler::schedule([] { server_loop(port, backlog); });
-        axle::Scheduler::yield();
+        axle::Scheduler::run();
         axle::Scheduler::fini();
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";

--- a/include/axle/scheduler.h
+++ b/include/axle/scheduler.h
@@ -22,6 +22,7 @@ class Scheduler {
     static void shutdown_all();
 
     static void schedule(std::function<void()> task);
+    static void run();
 
     static std::shared_ptr<Fiber> current_fiber();
     static void yield();
@@ -50,12 +51,11 @@ class Scheduler {
     void do_yield();
 
     void enqueue(std::shared_ptr<Fiber> fiber);
-    void run();
+    void do_run();
     void switch_to(std::shared_ptr<Fiber> target);
     void terminate_fiber();
 
     std::shared_ptr<Fiber> main_fiber_;
-    std::shared_ptr<Fiber> loop_fiber_;
     std::shared_ptr<Fiber> current_fiber_;
     std::shared_ptr<EventLoop> event_loop_;
 

--- a/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
+++ b/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
@@ -1,5 +1,8 @@
 leak:*_fetchInitializingClassList
 leak:*tlv_get_addr
 leak:*thread-local wrapper routine
-# Github is unable to pick up the previous two suppressions. This is a temporary work-around.
+leak:dyld4::APIs::setErrorString
+
+# Github is unable to pick up the previous suppressions. The following temporary work-arounds.
 leak:*SchedulerTest_RunTasks_Test
+leak:std::runtime_error::~runtime_error

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -63,6 +64,10 @@ void Scheduler::schedule(std::function<void()> task) {
     k_instance->do_schedule(std::move(task));
 }
 
+void Scheduler::run() {
+    k_instance->do_run();
+}
+
 std::shared_ptr<Fiber> Scheduler::current_fiber() {
     return k_instance->current_fiber_;
 }
@@ -82,10 +87,9 @@ std::shared_ptr<EventLoop> Scheduler::get_event_loop() {
 
 Scheduler::Scheduler(std::shared_ptr<EventLoop> event_loop, std::thread::id host_thread)
     : main_fiber_{std::make_shared<Fiber>()},
-      loop_fiber_{std::make_shared<Fiber>([] { k_instance->run(); })},
       current_fiber_{main_fiber_},
       event_loop_{std::move(event_loop)},
-      running_{true},
+      running_{false},
       host_thread_{host_thread} {}
 
 void Scheduler::do_schedule(std::function<void()> task) {
@@ -97,13 +101,16 @@ void Scheduler::do_schedule(std::function<void()> task) {
 }
 
 void Scheduler::do_yield() {
+    if (!running_) {
+        throw std::runtime_error("scheduler is not running");
+    }
     (void)blocked_fibers_.insert(current_fiber_);
-    switch_to(loop_fiber_);
+    switch_to(main_fiber_);
 }
 
 void Scheduler::do_fini() {
     // This is needed because we must return to the fiber executing the rest of this destructor
-    loop_fiber_ = current_fiber_;
+    main_fiber_ = current_fiber_;
 
     for (auto&& blocked_fiber : blocked_fibers_) {
         enqueue(blocked_fiber);
@@ -133,7 +140,9 @@ void Scheduler::enqueue(std::shared_ptr<Fiber> fiber) {
     ready_fibers_.push_back(std::move(fiber));
 }
 
-void Scheduler::run() {
+void Scheduler::do_run() {
+    running_.store(true);
+
     while (running_) {
         while (!ready_fibers_.empty()) {
             std::shared_ptr<Fiber> target = std::move(ready_fibers_.back());
@@ -147,10 +156,6 @@ void Scheduler::run() {
 
         event_loop_->tick();
     }
-
-    (void)blocked_fibers_.erase(main_fiber_);
-
-    switch_to(main_fiber_);
 }
 
 void Scheduler::switch_to(std::shared_ptr<Fiber> target) {
@@ -164,7 +169,7 @@ void Scheduler::switch_to(std::shared_ptr<Fiber> target) {
 
 void Scheduler::terminate_fiber() {
     terminated_fibers_.push_back(current_fiber_);
-    switch_to(loop_fiber_);
+    switch_to(main_fiber_);
 }
 
 } // namespace axle

--- a/test/scheduler_test.cpp
+++ b/test/scheduler_test.cpp
@@ -2,6 +2,7 @@
 
 #include "axle/scheduler.h"
 
+#include <stdexcept>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -33,7 +34,7 @@ TEST(SchedulerTest, RunTasks) {
         maybe_shutdown(a, 3);
     });
 
-    Scheduler::yield();
+    Scheduler::run();
     Scheduler::fini();
 
     ASSERT_EQ(3, a);
@@ -55,7 +56,7 @@ TEST(SchedulerTest, NestedScheduling) {
         });
     });
 
-    Scheduler::yield();
+    Scheduler::run();
     Scheduler::fini();
 
     ASSERT_EQ(2, a);
@@ -73,7 +74,7 @@ TEST(SchedulerTest, ManyTasks) {
         });
     }
 
-    Scheduler::yield();
+    Scheduler::run();
     Scheduler::fini();
 
     ASSERT_EQ(task_cnt, a);
@@ -94,7 +95,7 @@ TEST(SchedulerTest, Multithreaded) {
             });
         }
 
-        Scheduler::yield();
+        Scheduler::run();
         Scheduler::fini();
     });
 
@@ -107,7 +108,7 @@ TEST(SchedulerTest, Multithreaded) {
             });
         }
 
-        Scheduler::yield();
+        Scheduler::run();
         Scheduler::fini();
     });
 
@@ -116,6 +117,19 @@ TEST(SchedulerTest, Multithreaded) {
 
     ASSERT_EQ(task_cnt_a, a);
     ASSERT_EQ(task_cnt_b, b);
+}
+
+TEST(SchedulerTest, YieldBeforeRun) {
+    int a = 0;
+    Scheduler::init();
+
+    Scheduler::schedule([&] {
+        a++;
+        maybe_shutdown(a, 0);
+    });
+
+    ASSERT_THROW(Scheduler::yield(), std::runtime_error);
+    Scheduler::fini();
 }
 
 } // namespace axle


### PR DESCRIPTION
Modifies the usage pattern to:
```
axle::Scheduler::init()
axle::Scheduler::schedule(task)
axle::Scheduler::run()
axle::Scheduler::fini()
```
This way, `yield` can only be called from with a scheduled task and more importantly the run loop executes on the main fiber.