### PR TITLE
event_loop: Support signal handlers

### DIFF
--- a/include/axle/event.h
+++ b/include/axle/event.h
@@ -10,9 +10,10 @@
 
 namespace axle {
 
-using TimerEventCb = std::function<void(Status<None, uint32_t>)>;
 using FdEventIOCb = std::function<void(Status<int64_t, uint32_t>)>;
 using FdEventEOFCb = std::function<void()>;
+using TimerEventCb = std::function<void(Status<None, uint32_t>)>;
+using SignalEventCb = std::function<void(Status<int64_t, uint32_t>)>;
 
 class EventLoop {
   public:
@@ -31,11 +32,13 @@ class EventLoop {
                                      uint64_t timeout,
                                      bool periodic,
                                      const TimerEventCb& cb);
+    Status<None, int> register_signal(int signo, const SignalEventCb& cb);
 
     Status<None, int> remove_fd_read(int fd);
     Status<None, int> remove_fd_write(int fd);
     Status<None, None> remove_fd_eof(int fd);
     Status<None, int> remove_timer(uint64_t id);
+    Status<None, int> remove_signal(int signo);
 
     void tick();
     void run();
@@ -48,15 +51,17 @@ class EventLoop {
 
     int kq_;
     bool done_ = false;
-    std::unordered_map<uint64_t, TimerEventCb> timers_;
     std::unordered_map<uint64_t, FdEventIOCb> fd_read_;
     std::unordered_map<uint64_t, FdEventIOCb> fd_write_;
     std::unordered_map<uint64_t, FdEventEOFCb> fd_eof_;
+    std::unordered_map<uint64_t, TimerEventCb> timers_;
+    std::unordered_map<uint64_t, std::pair<SignalEventCb, void (*)(int)>> signals_;
 
-    void handle_shutdown(uint64_t id);
-    void handle_timer(uint64_t id, uint16_t flags, uint32_t fflags);
     void handle_fd_read(uint64_t fd, uint16_t flags, uint32_t fflags, int64_t data);
     void handle_fd_write(uint64_t fd, uint16_t flags, uint32_t fflags, int64_t data);
+    void handle_timer(uint64_t id, uint16_t flags, uint32_t fflags);
+    void handle_signal(uint64_t signo, uint16_t flags, uint32_t fflags, int64_t data);
+    void handle_shutdown(uint64_t id);
 
     void do_shutdown();
 };

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -5,12 +5,14 @@
 #include <sys/event.h>
 
 #include <cerrno>
+#include <csignal>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 
 #include <array>
 #include <stdexcept>
+#include <utility>
 
 #include "axle/status.h"
 
@@ -99,6 +101,31 @@ Status<None, int> EventLoop::register_timer(uint64_t id,
     return Status<None, int>::make_ok();
 }
 
+Status<None, int> EventLoop::register_signal(int signo, const SignalEventCb& cb) {
+    // Save the old handler so that we can restore it when `remove_signal` is called.
+    void (*const old_handler)(int) = signal(signo, SIG_IGN);
+
+    if (old_handler == SIG_ERR) {
+        perror("could not clear signal handler");
+
+        return Status<None, int>::make_err(errno);
+    }
+
+    struct kevent ev{};
+
+    EV_SET(&ev, signo, EVFILT_SIGNAL, EV_ADD, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to register signal filter");
+
+        return Status<None, int>::make_err(errno);
+    };
+    signals_[signo] = std::make_pair(cb, old_handler);
+
+    return Status<None, int>::make_ok();
+}
+
 Status<None, int> EventLoop::remove_fd_read(int fd) {
     if (fd_read_.erase(fd) != 1) {
         return Status<None, int>::make_err(0);
@@ -164,6 +191,31 @@ Status<None, int> EventLoop::remove_timer(uint64_t id) {
     return Status<None, int>::make_ok();
 }
 
+Status<None, int> EventLoop::remove_signal(int signo) {
+    void (*sighandler)(int) = signal(signo, signals_.at(signo).second);
+
+    if (sighandler == SIG_ERR) {
+        perror("failed to reset signal handler");
+        return Status<None, int>::make_err(0);
+    }
+    if (signals_.erase(signo) != 1) {
+        return Status<None, int>::make_err(0);
+    }
+
+    struct kevent ev{};
+
+    EV_SET(&ev, signo, EVFILT_SIGNAL, EV_DELETE, 0, 0, nullptr);
+
+    const int ret = kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to remove signal filter");
+
+        return Status<None, int>::make_err(errno);
+    };
+
+    return Status<None, int>::make_ok();
+}
+
 void EventLoop::tick() {
     std::array<struct kevent, k_max_event_cnt> evs{};
     const struct timespec ts{.tv_sec = 0, .tv_nsec = 0};
@@ -182,11 +234,6 @@ void EventLoop::tick() {
             break;
         }
 
-        case EVFILT_TIMER: {
-            handle_timer(ev.ident, ev.flags, ev.data);
-            break;
-        }
-
         case EVFILT_READ: {
             handle_fd_read(ev.ident, ev.flags, ev.fflags, ev.data);
             break;
@@ -194,6 +241,16 @@ void EventLoop::tick() {
 
         case EVFILT_WRITE: {
             handle_fd_write(ev.ident, ev.flags, ev.fflags, ev.data);
+            break;
+        }
+
+        case EVFILT_TIMER: {
+            handle_timer(ev.ident, ev.flags, ev.data);
+            break;
+        }
+
+        case EVFILT_SIGNAL: {
+            handle_signal(ev.ident, ev.flags, ev.fflags, ev.data);
             break;
         }
 
@@ -221,26 +278,6 @@ Status<None, int> EventLoop::shutdown() const {
     }
 
     return Status<None, int>::make_ok();
-}
-
-void EventLoop::handle_shutdown(const uint64_t id) {
-    if (id == k_shutdown_event_id) {
-        done_ = true;
-    }
-}
-
-void EventLoop::handle_timer(const uint64_t id, const uint16_t flags, const uint32_t fflags) {
-    if (!timers_.contains(id)) {
-        return;
-    }
-
-    // TODO (whalbawi): Confirm what happens when a timer fails and how errors are reported.
-    const TimerEventCb& cb = timers_[id];
-    if ((flags & EV_ERROR) != 0) {
-        cb(Status<None, uint32_t>::make_err(fflags));
-    } else {
-        cb(Status<None, uint32_t>::make_ok());
-    }
 }
 
 void EventLoop::handle_fd_read(const uint64_t fd,
@@ -279,6 +316,42 @@ void EventLoop::handle_fd_write(const uint64_t fd,
     if ((flags & EV_EOF) != 0 && fd_eof_.contains(fd)) {
         const FdEventEOFCb& cb = fd_eof_[fd];
         cb();
+    }
+}
+
+void EventLoop::handle_timer(const uint64_t id, const uint16_t flags, const uint32_t fflags) {
+    if (!timers_.contains(id)) {
+        return;
+    }
+
+    // TODO (whalbawi): Confirm what happens when a timer fails and how errors are reported.
+    const TimerEventCb& cb = timers_[id];
+    if ((flags & EV_ERROR) != 0) {
+        cb(Status<None, uint32_t>::make_err(fflags));
+    } else {
+        cb(Status<None, uint32_t>::make_ok());
+    }
+}
+
+void EventLoop::handle_signal(const uint64_t signo,
+                              const uint16_t flags,
+                              const uint32_t fflags,
+                              const int64_t data) {
+    if (!signals_.contains(signo)) {
+        return;
+    }
+
+    const SignalEventCb& cb = signals_[signo].first;
+    if ((flags & EV_ERROR) != 0) {
+        cb(Status<int64_t, uint32_t>::make_err(fflags));
+    } else {
+        cb(Status<int64_t, uint32_t>::make_ok(data));
+    }
+}
+
+void EventLoop::handle_shutdown(const uint64_t id) {
+    if (id == k_shutdown_event_id) {
+        done_ = true;
     }
 }
 

--- a/test/event_test.cpp
+++ b/test/event_test.cpp
@@ -2,6 +2,9 @@
 
 #include "axle/event.h"
 
+#include <signal.h>
+#include <unistd.h>
+
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
@@ -119,6 +122,111 @@ TEST(EventLoopTest, BadFd) {
     ASSERT_EQ(EBADF, status.err());
 
     ASSERT_TRUE(ev_loop.register_fd_eof(bogus_fd, []() {}).is_err());
+}
+
+TEST(EventLoopTest, Signal) {
+    EventLoop ev_loop{};
+
+    const int signo = SIGINT;
+
+    bool signaled = false;
+    const Status<None, int> status =
+        ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
+            EXPECT_TRUE(status.is_ok());
+            signaled = true;
+            const Status<None, int> res = ev_loop.shutdown();
+            EXPECT_TRUE(res.is_ok());
+        });
+    ASSERT_TRUE(status.is_ok());
+
+    EXPECT_EQ(0, kill(getpid(), signo));
+
+    ev_loop.run();
+
+    ASSERT_TRUE(signaled);
+}
+
+TEST(EventLoopTest, SignalUpdateHandler) {
+    EventLoop ev_loop{};
+    const int signo = SIGINT;
+    int handler = 0;
+
+    const Status<None, int> status1 =
+        ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
+            EXPECT_TRUE(status.is_ok());
+            handler = 1;
+            const Status<None, int> res = ev_loop.shutdown();
+            EXPECT_TRUE(res.is_ok());
+        });
+    ASSERT_TRUE(status1.is_ok());
+
+    const Status<None, int> status2 =
+        ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
+            EXPECT_TRUE(status.is_ok());
+            handler = 2;
+            const Status<None, int> res = ev_loop.shutdown();
+            EXPECT_TRUE(res.is_ok());
+        });
+    ASSERT_TRUE(status2.is_ok());
+
+    EXPECT_EQ(0, kill(getpid(), signo));
+
+    ev_loop.run();
+
+    ASSERT_EQ(2, handler);
+}
+
+TEST(EventLoopTest, SignalDifferentSignalNumber) {
+    EventLoop ev_loop{};
+    const int signo = SIGINT;
+    bool signaled = false;
+
+    EXPECT_NE(SIG_ERR, signal(signo, SIG_DFL));
+    const Status<None, int> status =
+        ev_loop.register_signal(SIGTERM, [&](Status<int64_t, uint32_t> status) {
+            EXPECT_TRUE(status.is_ok());
+            signaled = true;
+            const Status<None, int> res = ev_loop.shutdown();
+            EXPECT_TRUE(res.is_ok());
+        });
+    ASSERT_TRUE(status.is_ok());
+
+    ASSERT_EXIT(
+        {
+            EXPECT_EQ(0, kill(getpid(), signo));
+            ev_loop.run();
+        },
+        testing::KilledBySignal(SIGINT),
+        "");
+
+    ASSERT_FALSE(signaled);
+}
+
+TEST(EventLoopTest, SignalCancelHandler) {
+    EventLoop ev_loop{};
+    const int signo = SIGINT;
+    bool signaled = false;
+
+    EXPECT_NE(SIG_ERR, signal(signo, SIG_DFL));
+    const Status<None, int> status =
+        ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
+            EXPECT_TRUE(status.is_ok());
+            signaled = true;
+            const Status<None, int> res = ev_loop.shutdown();
+            EXPECT_TRUE(res.is_ok());
+        });
+    ASSERT_TRUE(status.is_ok());
+    ASSERT_TRUE(ev_loop.remove_signal(signo).is_ok());
+
+    ASSERT_EXIT(
+        {
+            EXPECT_EQ(0, kill(getpid(), signo));
+            ev_loop.run();
+        },
+        testing::KilledBySignal(SIGINT),
+        "");
+
+    ASSERT_FALSE(signaled);
 }
 
 class IncrementServer {


### PR DESCRIPTION
Provides the ability to register signal handlers with the event loop. The delivery mechanism is via `kqueue` in that the `kevent` call does not error out with `EINTR`. The existing handler for the registered signal is preserved and reinstalled once the event loop one is removed.