### PR TITLE
scheduler: Support application entry point

### DIFF
--- a/examples/async_echo_server/main.cpp
+++ b/examples/async_echo_server/main.cpp
@@ -1,12 +1,9 @@
-#include <signal.h>
-
 #include <cerrno>
 #include <csignal>
 #include <cstddef>
 #include <cstdint>
 
 #include <array>
-#include <atomic>
 #include <exception>
 #include <iostream>
 #include <memory>
@@ -46,8 +43,6 @@ void connection_handler(const std::shared_ptr<axle::AsyncSocket>& socket) {
     }
 }
 
-volatile std::atomic_bool running{false};
-
 void server_loop(int port, int backlog) {
     const axle::AsyncServerSocket socket{};
     axle::Status<axle::None, int> listen_status = socket.listen(port, backlog);
@@ -56,10 +51,9 @@ void server_loop(int port, int backlog) {
         return;
     }
 
-    running.store(true);
     std::cerr << "Echo server launched on 127.0.0.1:" << port << "\n";
 
-    while (running.load()) {
+    for (;;) {
         axle::Status<axle::AsyncSocket, int> accept_status = socket.accept();
         if (accept_status.is_err()) {
             std::cerr << "could not accept connection - error: " << accept_status.err() << "\n";
@@ -74,31 +68,16 @@ void server_loop(int port, int backlog) {
     }
 }
 
-void signal_handler(int signal) {
-    (void)signal;
-
-    running.store(false);
-    axle::Scheduler::shutdown_all();
-}
-
 } // namespace
 
 int main(int argc, char** argv) {
     (void)argc;
     (void)argv;
 
-    if (signal(SIGINT, signal_handler) != 0) {
-        std::cerr << "failed to register signal handler - error: " << errno << "\n";
-        return -1;
-    }
-
     try {
         constexpr int port = 8080;
         constexpr int backlog = 128;
-        axle::Scheduler::init();
-        axle::Scheduler::schedule([] { server_loop(port, backlog); }, "entry_point");
-        axle::Scheduler::run();
-        axle::Scheduler::fini();
+        axle::Scheduler::enter([] { server_loop(port, backlog); });
     } catch (const std::exception& e) {
         std::cerr << e.what() << "\n";
         return -1;

--- a/include/axle/scheduler.h
+++ b/include/axle/scheduler.h
@@ -16,6 +16,7 @@ class Fiber;
 
 class Scheduler {
   public:
+    static void enter(std::function<void()> entry_point);
     static void init();
     static void fini();
     static void shutdown();
@@ -46,6 +47,7 @@ class Scheduler {
     Scheduler& operator=(Scheduler&&) = delete;
 
     void do_fini();
+    void do_enter(std::function<void()> entry_point);
     void do_shutdown();
     void do_schedule(std::function<void()> task, std::string tag);
     void do_yield();

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -14,12 +14,19 @@
 #include "debug.h"
 #include "fiber.h"
 #include "axle/event.h"
+#include "axle/status.h"
 
 namespace axle {
 
 thread_local Scheduler* Scheduler::k_instance = nullptr;
 std::mutex Scheduler::k_schedulers_mtx;
 std::unordered_map<std::thread::id, std::unique_ptr<Scheduler>> Scheduler::k_schedulers;
+
+void Scheduler::enter(std::function<void()> entry_point) {
+    Scheduler::init();
+    k_instance->do_enter(std::move(entry_point));
+    log_dbg("DONE");
+}
 
 void Scheduler::init() {
     if (k_instance == nullptr) {
@@ -138,6 +145,25 @@ void Scheduler::do_fini() {
     while (!terminated_fibers_.empty()) {
         terminated_fibers_.pop_back();
     }
+}
+
+void Scheduler::do_enter(std::function<void()> entry_point) {
+    log_dbg("ENTER");
+    do_schedule(std::move(entry_point), "entry_point");
+    if (signal(SIGINT, SIG_IGN) == SIG_ERR) {
+        throw std::runtime_error("could not replace signal handler for SIGINT");
+    }
+    const Status<None, int> status = event_loop_->register_signal(SIGINT, [&](auto status) {
+        (void)status;
+        do_schedule([&] { do_shutdown(); }, "shutdown");
+    });
+
+    if (status.is_err()) {
+        throw std::runtime_error("could not register shutdown signal handler with event loop");
+    }
+
+    do_run();
+    do_fini();
 }
 
 void Scheduler::do_shutdown() {


### PR DESCRIPTION
Introduces the `enter` method that allows an application to schedule long-lived work using the one-liner:
```
Scheduler::enter(server_loop);
```
Underneath the hood, this method does the following:
- Initializes the thread-local `Scheduler`.
- Schedules the task.
- Registers a signal handler so that SIGINT shuts down the `Scheduler`.
- Drains the fiber queue by scheduling blocked fibers and then interrupting all fibers.