### PR TITLE
poller: Make the poller platform specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,13 +90,16 @@ set(AXLE_SRC_LIST
     ${AXLE_SRC_DIR}/axle.cpp
     ${AXLE_SRC_DIR}/event.cpp
     ${AXLE_SRC_DIR}/fiber.cpp
-    ${AXLE_SRC_DIR}/poller.cpp
     ${AXLE_SRC_DIR}/scheduler.cpp
     ${AXLE_SRC_DIR}/socket.cpp
     ${AXLE_SRC_DIR}/fiber_arm64.cpp
     ${AXLE_SRC_DIR}/asm/fiber_arm64.S
     ${CMAKE_CURRENT_BINARY_DIR}/gen/version.cpp
 )
+
+if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD|Darwin")
+    list(APPEND AXLE_SRC_LIST ${AXLE_SRC_DIR}/poller_bsd.cpp)
+endif ()
 
 # Test files
 set(AXLE_TEST_LIST

--- a/include/axle/event.h
+++ b/include/axle/event.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
 #include <functional>
+#include <memory>
 #include <unordered_map>
 
 #include "axle/status.h"
@@ -31,17 +31,14 @@ class EventLoop {
     Status<None, int> register_fd_read(int fd, const FdEventIOCb& cb);
     Status<None, int> register_fd_write(int fd, const FdEventIOCb& cb);
     Status<None, None> register_fd_eof(int fd, const FdEventEOFCb& cb);
-    Status<None, int> register_timer(uint64_t id,
-                                     uint64_t timeout,
-                                     bool periodic,
-                                     const TimerEventCb& cb);
-    Status<None, int> register_signal(int signo, const SignalEventCb& cb);
+    Status<int, int> register_timer(uint64_t timeout, bool periodic, const TimerEventCb& cb);
+    Status<int, int> register_signal(int signo, const SignalEventCb& cb);
 
     Status<None, int> remove_fd_read(int fd);
     Status<None, int> remove_fd_write(int fd);
     Status<None, None> remove_fd_eof(int fd);
-    Status<None, int> remove_timer(uint64_t id);
-    Status<None, int> remove_signal(int signo);
+    Status<None, int> remove_timer(int id);
+    Status<None, int> remove_signal(int fd);
 
     void tick();
     void run();
@@ -49,15 +46,14 @@ class EventLoop {
     Status<None, int> shutdown() const;
 
   private:
-    static constexpr uint64_t k_shutdown_event_id = 19;
-
     std::unique_ptr<Poller> poller_;
     bool done_ = false;
     std::unordered_map<uint64_t, FdEventIOCb> fd_read_;
     std::unordered_map<uint64_t, FdEventIOCb> fd_write_;
     std::unordered_map<uint64_t, FdEventEOFCb> fd_eof_;
     std::unordered_map<uint64_t, TimerEventCb> timers_;
-    std::unordered_map<uint64_t, std::pair<SignalEventCb, void (*)(int)>> signals_;
+    std::unordered_map<uint64_t, SignalEventCb> signals_;
+    int shutdown_event_id_;
 
     void handle_fd_read(const PollOutcome& outcome);
     void handle_fd_write(const PollOutcome& outcome);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,27 +1,26 @@
 #include "axle/event.h"
 
-#include <poller.h>
-#include <time.h>
-
 #include <cerrno>
-#include <csignal>
 #include <cstdint>
 #include <cstdio>
 
 #include <memory>
 #include <stdexcept>
-#include <utility>
 #include <vector>
 
+#include "poller.h"
 #include "axle/status.h"
 
 namespace axle {
 
 EventLoop::EventLoop() : poller_(std::make_unique<Poller>()) {
     // Register shutdown handler
-    if (poller_->register_user_event(k_shutdown_event_id) != 0) {
+    const int fd = poller_->register_user_event();
+    if (fd == -1) {
         throw std::runtime_error("failed to register shutdown handler");
     }
+
+    shutdown_event_id_ = fd;
 }
 
 EventLoop::~EventLoop() = default;
@@ -58,38 +57,28 @@ Status<None, None> EventLoop::register_fd_eof(int fd, const FdEventEOFCb& cb) {
     return Status<None, None>::make_ok();
 }
 
-Status<None, int> EventLoop::register_timer(uint64_t id,
-                                            uint64_t timeout,
-                                            bool periodic,
-                                            const TimerEventCb& cb) {
-    int ret = poller_->register_timer(id, timeout, periodic);
-    if (ret != 0) {
-        return Status<None, int>::make_err(ret);
+Status<int, int> EventLoop::register_timer(uint64_t timeout,
+                                           bool periodic,
+                                           const TimerEventCb& cb) {
+    int fd = poller_->register_timer(timeout, periodic);
+    if (fd == -1) {
+        return Status<int, int>::make_err(fd);
     }
 
-    timers_[id] = cb;
+    timers_[fd] = cb;
 
-    return Status<None, int>::make_ok();
+    return Status<int, int>::make_ok(fd);
 }
 
-Status<None, int> EventLoop::register_signal(int signo, const SignalEventCb& cb) {
-    // Save the old handler so that we can restore it when `remove_signal` is called.
-    void (*const old_handler)(int) = signal(signo, SIG_IGN);
-
-    if (old_handler == SIG_ERR) {
-        perror("could not clear signal handler");
-
-        return Status<None, int>::make_err(errno);
+Status<int, int> EventLoop::register_signal(int signo, const SignalEventCb& cb) {
+    int fd = poller_->register_signal(signo);
+    if (fd == -1) {
+        return Status<int, int>::make_err(fd);
     }
 
-    int ret = poller_->register_signal(signo);
-    if (ret != 0) {
-        return Status<None, int>::make_err(ret);
-    }
+    signals_[fd] = cb;
 
-    signals_[signo] = std::make_pair(cb, old_handler);
-
-    return Status<None, int>::make_ok();
+    return Status<int, int>::make_ok(fd);
 }
 
 Status<None, int> EventLoop::remove_fd_read(int fd) {
@@ -126,7 +115,7 @@ Status<None, None> EventLoop::remove_fd_eof(int fd) {
     return Status<None, None>::make_ok();
 }
 
-Status<None, int> EventLoop::remove_timer(uint64_t id) {
+Status<None, int> EventLoop::remove_timer(int id) {
     if (timers_.erase(id) != 1) {
         return Status<None, int>::make_err(0);
     }
@@ -139,20 +128,13 @@ Status<None, int> EventLoop::remove_timer(uint64_t id) {
     return Status<None, int>::make_ok();
 }
 
-Status<None, int> EventLoop::remove_signal(int signo) {
-    void (*sighandler)(int) = signal(signo, signals_.at(signo).second);
-
-    if (sighandler == SIG_ERR) {
-        perror("failed to reset signal handler");
-        return Status<None, int>::make_err(0);
-    }
-
-    int ret = poller_->remove_signal(signo);
+Status<None, int> EventLoop::remove_signal(int fd) {
+    int ret = poller_->remove_signal(fd);
     if (ret != 0) {
         return Status<None, int>::make_err(ret);
     }
 
-    if (signals_.erase(signo) != 1) {
+    if (signals_.erase(fd) != 1) {
         return Status<None, int>::make_err(0);
     }
 
@@ -200,7 +182,7 @@ void EventLoop::run() {
 }
 
 Status<None, int> EventLoop::shutdown() const {
-    int ret = poller_->notify_user(k_shutdown_event_id);
+    int ret = poller_->notify_user(shutdown_event_id_);
     if (ret != 0) {
         perror("failed to schedule shutdown event");
 
@@ -249,7 +231,7 @@ void EventLoop::handle_timer(const PollOutcome& outcome) {
         return;
     }
 
-    const TimerEventCb& cb = timers_[outcome.id];
+    const TimerEventCb cb = timers_[outcome.id];
     if (outcome.state == PollState::ERR) {
         cb(Status<None, uint32_t>::make_err(0));
     } else {
@@ -262,7 +244,7 @@ void EventLoop::handle_signal(const PollOutcome& outcome) {
         return;
     }
 
-    const SignalEventCb& cb = signals_[outcome.id].first;
+    const SignalEventCb& cb = signals_[outcome.id];
     if (outcome.state == PollState::ERR) {
         cb(Status<int64_t, uint32_t>::make_err(0));
     } else {
@@ -271,7 +253,7 @@ void EventLoop::handle_signal(const PollOutcome& outcome) {
 }
 
 void EventLoop::handle_shutdown(const PollOutcome& outcome) {
-    if (outcome.id == k_shutdown_event_id) {
+    if (outcome.id == shutdown_event_id_) {
         done_ = true;
     }
 }

--- a/src/poller.h
+++ b/src/poller.h
@@ -1,61 +1,7 @@
 #pragma once
 
-#include <sys/event.h>
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include "poller_bsd.h" // IWYU pragma: export
+#endif                  // defined(__APPLE__) || defined(__FreeBSD__)
 
-#include <vector>
-
-namespace axle {
-
-enum class PollState : uint8_t {
-    ERR,
-    OK,
-};
-
-enum class PollEvent : std::uint8_t {
-    USER,
-    FD_READ,
-    FD_WRITE,
-    FD_EOF,
-    TIMER,
-    SIGNAL,
-};
-
-struct PollOutcome {
-    uint64_t id;
-    PollEvent event;
-    PollState state;
-};
-
-class Poller {
-  public:
-    Poller();
-    Poller(const Poller&) = default;
-    Poller(Poller&&) = delete;
-    Poller& operator=(const Poller&) = default;
-    Poller& operator=(Poller&&) = delete;
-
-    ~Poller() noexcept;
-
-    std::vector<PollOutcome> poll() const;
-
-    int register_user_event(int id) const;
-    int register_fd_read(int fd) const;
-    int register_fd_write(int fd) const;
-    int register_timer(uint64_t id, uint64_t timeout, bool periodic) const;
-    int register_signal(int signo) const;
-
-    int notify_user(int id) const;
-
-    int remove_user_event(int id) const;
-    int remove_fd_read(int fd) const;
-    int remove_fd_write(int fd) const;
-    int remove_timer(uint64_t id) const;
-    int remove_signal(int signo) const;
-
-  private:
-    static constexpr size_t k_max_event_cnt = 64;
-
-    int poller_fd_;
-};
-
-} // namespace axle
+#include "poller_common.h" // IWYU pragma: export

--- a/src/poller_bsd.cpp
+++ b/src/poller_bsd.cpp
@@ -1,10 +1,12 @@
-#include "poller.h"
+#include "poller_bsd.h"
 
+#include <signal.h>
 #include <time.h>
 #include <unistd.h>
 #include <sys/event.h>
 
 #include <cerrno>
+#include <csignal>
 #include <cstdint>
 #include <cstdio>
 
@@ -12,11 +14,42 @@
 #include <stdexcept>
 #include <vector>
 
+#include "poller_common.h"
+
 namespace axle {
+
+namespace {
+
+int signal_block(int signo) {
+    auto old = signal(signo, SIG_IGN);
+    if (old == SIG_ERR) {
+        return errno;
+    }
+
+    return 0;
+}
+
+int signal_unblock(int signo) {
+    auto old = signal(signo, SIG_DFL);
+    if (old == SIG_ERR) {
+        return errno;
+    }
+
+    return 0;
+}
+
+} // namespace
 
 Poller::Poller() : poller_fd_(kqueue()) {
     if (poller_fd_ == -1) {
         throw std::runtime_error("failed to initialize poller with kqueue");
+    }
+}
+
+Poller::~Poller() noexcept {
+    const int ret = close(poller_fd_);
+    if (ret == -1) {
+        perror("failed to close poller file descriptor");
     }
 }
 
@@ -80,19 +113,6 @@ std::vector<PollOutcome> Poller::poll() const {
     return outcomes;
 }
 
-int Poller::register_user_event(int id) const {
-    struct kevent ev{};
-    EV_SET(&ev, id, EVFILT_USER, EV_ADD, 0, 0, nullptr);
-
-    const int ret = kevent(poller_fd_, &ev, 1, nullptr, 0, nullptr);
-    if (ret != 0) {
-        perror("failed to register kqueue user event");
-        return errno;
-    }
-
-    return 0;
-}
-
 int Poller::register_fd_read(int fd) const {
     struct kevent ev{};
     EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, nullptr);
@@ -121,7 +141,22 @@ int Poller::register_fd_write(int fd) const {
     return 0;
 }
 
-int Poller::register_timer(uint64_t id, uint64_t timeout, bool periodic) const {
+int Poller::register_user_event() {
+    const int id = next_id_++;
+    struct kevent ev{};
+    EV_SET(&ev, id, EVFILT_USER, EV_ADD, 0, 0, nullptr);
+
+    const int ret = kevent(poller_fd_, &ev, 1, nullptr, 0, nullptr);
+    if (ret != 0) {
+        perror("failed to register kqueue user event");
+        return errno;
+    }
+
+    return id;
+}
+
+int Poller::register_timer(uint64_t timeout, bool periodic) {
+    const int id = next_id_++;
     struct kevent ev{};
     const uint16_t oneshot = periodic ? 0 : EV_ONESHOT;
     EV_SET(&ev, id, EVFILT_TIMER, EV_ADD | oneshot, NOTE_NSECONDS, timeout, nullptr);
@@ -133,7 +168,7 @@ int Poller::register_timer(uint64_t id, uint64_t timeout, bool periodic) const {
         return errno;
     };
 
-    return 0;
+    return id;
 }
 
 int Poller::register_signal(int signo) const {
@@ -147,7 +182,12 @@ int Poller::register_signal(int signo) const {
         return errno;
     };
 
-    return 0;
+    const int ret_signal = signal_block(signo);
+    if (ret_signal != 0) {
+        return ret_signal;
+    }
+
+    return signo;
 }
 
 int Poller::notify_user(int id) const {
@@ -157,20 +197,6 @@ int Poller::notify_user(int id) const {
     const int ret = kevent(poller_fd_, &ev, 1, nullptr, 0, nullptr);
     if (ret == -1) {
         perror("failed to register signal filter");
-
-        return errno;
-    };
-
-    return 0;
-}
-
-int Poller::remove_user_event(int id) const {
-    struct kevent ev{};
-    EV_SET(&ev, id, EVFILT_USER, EV_DELETE, 0, 0, nullptr);
-
-    const int ret = kevent(poller_fd_, &ev, 1, nullptr, 0, nullptr);
-    if (ret == -1) {
-        perror("failed to remove user filter");
 
         return errno;
     };
@@ -206,7 +232,21 @@ int Poller::remove_fd_write(int fd) const {
     return 0;
 }
 
-int Poller::remove_timer(uint64_t id) const {
+int Poller::remove_user_event(int id) const {
+    struct kevent ev{};
+    EV_SET(&ev, id, EVFILT_USER, EV_DELETE, 0, 0, nullptr);
+
+    const int ret = kevent(poller_fd_, &ev, 1, nullptr, 0, nullptr);
+    if (ret == -1) {
+        perror("failed to remove user filter");
+
+        return errno;
+    };
+
+    return 0;
+}
+
+int Poller::remove_timer(int id) const {
     struct kevent ev{};
     EV_SET(&ev, id, EVFILT_TIMER, EV_DELETE, 0, 0, nullptr);
 
@@ -220,9 +260,14 @@ int Poller::remove_timer(uint64_t id) const {
     return 0;
 }
 
-int Poller::remove_signal(int signo) const {
+int Poller::remove_signal(int id) const {
+    const int ret_signal = signal_unblock(id);
+    if (ret_signal != 0) {
+        return ret_signal;
+    }
+
     struct kevent ev{};
-    EV_SET(&ev, signo, EVFILT_SIGNAL, EV_DELETE, 0, 0, nullptr);
+    EV_SET(&ev, id, EVFILT_SIGNAL, EV_DELETE, 0, 0, nullptr);
 
     const int ret = kevent(poller_fd_, &ev, 1, nullptr, 0, nullptr);
     if (ret == -1) {
@@ -232,13 +277,6 @@ int Poller::remove_signal(int signo) const {
     };
 
     return 0;
-}
-
-Poller::~Poller() noexcept {
-    const int ret = close(poller_fd_);
-    if (ret == -1) {
-        perror("failed to close poller file descriptor");
-    }
 }
 
 } // namespace axle

--- a/src/poller_bsd.h
+++ b/src/poller_bsd.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <atomic>
+#include <vector>
+
+namespace axle {
+
+struct PollOutcome;
+
+class Poller {
+  public:
+    Poller();
+    Poller(const Poller&) = delete;
+    Poller(Poller&&) = delete;
+    Poller& operator=(const Poller&) = delete;
+    Poller& operator=(Poller&&) = delete;
+
+    ~Poller() noexcept;
+
+    std::vector<PollOutcome> poll() const;
+
+    int register_fd_read(int fd) const;
+    int register_fd_write(int fd) const;
+    int register_user_event();
+    int register_timer(uint64_t timeout, bool periodic);
+    int register_signal(int signo) const;
+
+    int notify_user(int id) const;
+
+    int remove_fd_read(int fd) const;
+    int remove_fd_write(int fd) const;
+    int remove_user_event(int id) const;
+    int remove_timer(int id) const;
+    int remove_signal(int id) const;
+
+  private:
+    static constexpr size_t k_max_event_cnt = 64;
+
+    int poller_fd_;
+    std::atomic_int next_id_;
+};
+
+} // namespace axle

--- a/src/poller_common.h
+++ b/src/poller_common.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace axle {
+
+enum class PollState : uint8_t {
+    OK,
+    ERR,
+};
+
+enum class PollEvent : uint8_t {
+    USER = 0,
+    FD_READ,
+    FD_WRITE,
+    FD_EOF,
+    TIMER,
+    SIGNAL,
+};
+
+struct PollOutcome {
+    int id;
+    PollEvent event;
+    PollState state;
+};
+
+} // namespace axle

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -150,10 +150,7 @@ void Scheduler::do_fini() {
 void Scheduler::do_enter(std::function<void()> entry_point) {
     log_dbg("ENTER");
     do_schedule(std::move(entry_point), "entry_point");
-    if (signal(SIGINT, SIG_IGN) == SIG_ERR) {
-        throw std::runtime_error("could not replace signal handler for SIGINT");
-    }
-    const Status<None, int> status = event_loop_->register_signal(SIGINT, [&](auto status) {
+    const Status<int, int> status = event_loop_->register_signal(SIGINT, [&](auto status) {
         (void)status;
         do_schedule([&] { do_shutdown(); }, "shutdown");
     });

--- a/test/event_test.cpp
+++ b/test/event_test.cpp
@@ -6,8 +6,10 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <csignal>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 
 #include <array>
 #include <atomic>
@@ -25,7 +27,6 @@ namespace axle {
 
 TEST(EventLoopTest, TimerOneshot) {
     EventLoop ev_loop;
-    const int timer_id = 1;
     const uint64_t delay = 5e8;
     bool called = false;
 
@@ -38,7 +39,7 @@ TEST(EventLoopTest, TimerOneshot) {
         EXPECT_TRUE(res.is_ok());
     };
 
-    const Status<None, int> res = ev_loop.register_timer(timer_id, delay, false /* periodic */, cb);
+    const Status<int, int> res = ev_loop.register_timer(delay, false /* periodic */, cb);
     ASSERT_TRUE(res.is_ok());
 
     ev_loop.run();
@@ -48,7 +49,6 @@ TEST(EventLoopTest, TimerOneshot) {
 
 TEST(EventLoopTest, TimerPeriodic) {
     EventLoop ev_loop;
-    const int timer_id = 1;
     const uint64_t delay = 5e8;
     int counter = 0;
     int counter_max = 4;
@@ -64,7 +64,7 @@ TEST(EventLoopTest, TimerPeriodic) {
         }
     };
 
-    const Status<None, int> res = ev_loop.register_timer(timer_id, delay, true /* periodic */, cb);
+    const Status<int, int> res = ev_loop.register_timer(delay, true /* periodic */, cb);
     ASSERT_TRUE(res.is_ok());
 
     ev_loop.run();
@@ -72,9 +72,11 @@ TEST(EventLoopTest, TimerPeriodic) {
     ASSERT_EQ(counter_max, counter);
 }
 
+// TODO (whalbawi): Fill me
+TEST(EventLoopTest, DISABLED_TimerDoubleRegister) {}
+
 TEST(EventLoopTest, TimerUpdate) {
     EventLoop ev_loop;
-    int timer_id = 1;
     const uint64_t delay = 5e8;
     int counter = 0;
     int counter_max = 4;
@@ -89,28 +91,32 @@ TEST(EventLoopTest, TimerUpdate) {
         EXPECT_TRUE(res.is_ok());
     };
 
+    int fd = 0;
     const TimerEventCb cb_periodic = [&](Status<None, uint32_t> status) {
         EXPECT_TRUE(status.is_ok());
         ++counter;
         if (counter == counter_max) {
-            const Status<None, int> res =
-                ev_loop.register_timer(timer_id, delay, false /* periodic */, cb_oneshot);
-            EXPECT_TRUE(res.is_ok());
+            const Status<None, int> rem_res = ev_loop.remove_timer(fd);
+            EXPECT_TRUE(rem_res.is_ok());
+            const Status<int, int> reg_res =
+                ev_loop.register_timer(delay, false /* periodic */, cb_oneshot);
+            EXPECT_TRUE(reg_res.is_ok());
         }
     };
 
-    const Status<None, int> res =
-        ev_loop.register_timer(timer_id, delay, true /* periodic */, cb_periodic);
+    Status<int, int> res = ev_loop.register_timer(delay, true /* periodic */, cb_periodic);
     ASSERT_TRUE(res.is_ok());
+    fd = res.ok();
 
     ev_loop.run();
 
     ASSERT_EQ(counter_max, counter);
+    ASSERT_TRUE(called);
 }
 
 TEST(EventLoopTest, BadFd) {
     EventLoop ev_loop{};
-    const int bogus_fd = 5;
+    const int bogus_fd = -2;
 
     Status<None, int> status = ev_loop.register_fd_read(bogus_fd, [](Status<int64_t, uint32_t>) {});
     ASSERT_TRUE(status.is_err());
@@ -129,13 +135,12 @@ TEST(EventLoopTest, Signal) {
     const int signo = SIGINT;
 
     bool signaled = false;
-    const Status<None, int> status =
-        ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
-            EXPECT_TRUE(status.is_ok());
-            signaled = true;
-            const Status<None, int> res = ev_loop.shutdown();
-            EXPECT_TRUE(res.is_ok());
-        });
+    Status<int, int> status = ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
+        EXPECT_TRUE(status.is_ok());
+        signaled = true;
+        const Status<None, int> res = ev_loop.shutdown();
+        EXPECT_TRUE(res.is_ok());
+    });
     ASSERT_TRUE(status.is_ok());
 
     EXPECT_EQ(0, kill(getpid(), signo));
@@ -143,6 +148,7 @@ TEST(EventLoopTest, Signal) {
     ev_loop.run();
 
     ASSERT_TRUE(signaled);
+    ASSERT_TRUE(ev_loop.remove_signal(status.ok()).is_ok());
 }
 
 TEST(EventLoopTest, SignalUpdateHandler) {
@@ -150,7 +156,7 @@ TEST(EventLoopTest, SignalUpdateHandler) {
     const int signo = SIGINT;
     int handler = 0;
 
-    const Status<None, int> status1 =
+    Status<int, int> status1 =
         ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
             EXPECT_TRUE(status.is_ok());
             handler = 1;
@@ -159,7 +165,10 @@ TEST(EventLoopTest, SignalUpdateHandler) {
         });
     ASSERT_TRUE(status1.is_ok());
 
-    const Status<None, int> status2 =
+    const Status<None, int> remove_status = ev_loop.remove_signal(status1.ok());
+    ASSERT_TRUE(remove_status.is_ok());
+
+    Status<int, int> status2 =
         ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
             EXPECT_TRUE(status.is_ok());
             handler = 2;
@@ -173,6 +182,7 @@ TEST(EventLoopTest, SignalUpdateHandler) {
     ev_loop.run();
 
     ASSERT_EQ(2, handler);
+    ASSERT_TRUE(ev_loop.remove_signal(status2.ok()).is_ok());
 }
 
 TEST(EventLoopTest, SignalDifferentSignalNumber) {
@@ -181,7 +191,7 @@ TEST(EventLoopTest, SignalDifferentSignalNumber) {
     bool signaled = false;
 
     EXPECT_NE(SIG_ERR, signal(signo, SIG_DFL));
-    const Status<None, int> status =
+    Status<int, int> status =
         ev_loop.register_signal(SIGTERM, [&](Status<int64_t, uint32_t> status) {
             EXPECT_TRUE(status.is_ok());
             signaled = true;
@@ -195,10 +205,11 @@ TEST(EventLoopTest, SignalDifferentSignalNumber) {
             EXPECT_EQ(0, kill(getpid(), signo));
             ev_loop.run();
         },
-        testing::KilledBySignal(SIGINT),
+        testing::KilledBySignal(signo),
         "");
 
     ASSERT_FALSE(signaled);
+    ASSERT_TRUE(ev_loop.remove_signal(status.ok()).is_ok());
 }
 
 TEST(EventLoopTest, SignalCancelHandler) {
@@ -206,23 +217,21 @@ TEST(EventLoopTest, SignalCancelHandler) {
     const int signo = SIGINT;
     bool signaled = false;
 
-    EXPECT_NE(SIG_ERR, signal(signo, SIG_DFL));
-    const Status<None, int> status =
-        ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
-            EXPECT_TRUE(status.is_ok());
-            signaled = true;
-            const Status<None, int> res = ev_loop.shutdown();
-            EXPECT_TRUE(res.is_ok());
-        });
+    Status<int, int> status = ev_loop.register_signal(signo, [&](Status<int64_t, uint32_t> status) {
+        EXPECT_TRUE(status.is_ok());
+        signaled = true;
+        const Status<None, int> res = ev_loop.shutdown();
+        EXPECT_TRUE(res.is_ok());
+    });
     ASSERT_TRUE(status.is_ok());
-    ASSERT_TRUE(ev_loop.remove_signal(signo).is_ok());
+    ASSERT_TRUE(ev_loop.remove_signal(status.ok()).is_ok());
 
     ASSERT_EXIT(
         {
             EXPECT_EQ(0, kill(getpid(), signo));
             ev_loop.run();
         },
-        testing::KilledBySignal(SIGINT),
+        testing::KilledBySignal(signo),
         "");
 
     ASSERT_FALSE(signaled);


### PR DESCRIPTION
In addition, have the register_{timer, signal, user_event} APIs return an identifier in as opposed to be being provided by the client. Such contracts adapts better for the upcoming epoll-based implementation for Linux.