### PR TITLE
poller: Implement epoll-based backend for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD|Darwin")
     list(APPEND AXLE_SRC_LIST ${AXLE_SRC_DIR}/poller_bsd.cpp)
 endif ()
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    list(APPEND AXLE_SRC_LIST ${AXLE_SRC_DIR}/poller_linux.cpp)
+endif ()
+
 # Test files
 set(AXLE_TEST_LIST
     ${AXLE_TEST_DIR}/axle_test.cpp

--- a/bench/async_echo_server.cpp
+++ b/bench/async_echo_server.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <memory>
 #include <span>
+#include <sstream>
 #include <thread>
 #include <utility>
 

--- a/include/axle/tcp.h
+++ b/include/axle/tcp.h
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <cstdint>
 
+#include <atomic>
 #include <memory>
 #include <span>
 #include <utility>

--- a/src/debug.h
+++ b/src/debug.h
@@ -3,8 +3,17 @@
 #include <concepts>
 #include <format>
 #include <memory>
+#include <type_traits>
 
 #include "fiber.h"
+
+#if !defined(AXLE_DEBUG_ENABLED)
+#if !defined(NDEBUG)
+#define AXLE_DEBUG_ENABLED 1
+#else
+#define AXLE_DEBUG_ENABLED 0
+#endif // !defined(NDEBUG)
+#endif // !defined(AXLE_DEBUG_ENABLED)
 
 #if AXLE_DEBUG_ENABLED
 #include <iostream>
@@ -16,7 +25,8 @@
 
 template <typename T>
 concept pointer_to_fiber = requires(const T& t) {
-    { std::to_address(t) } -> std::convertible_to<const axle::Fiber*>;
+    { *t } -> std::convertible_to<const axle::Fiber&>;
+    requires std::is_pointer_v<T> || requires { t.operator->(); };
 };
 
 template <pointer_to_fiber T>
@@ -37,6 +47,7 @@ struct std::formatter<T> {
         return std::format_to(ctx.out(), "{}", fiber->tag_);
     }
 };
+
 namespace axle {
 
 template <typename... Args>
@@ -56,5 +67,14 @@ void log_dbg(std::format_string<Args...> fmt, Args&&... args) {
               << std::format(fmt, std::forward<Args>(args)...) << '\n';
 #endif
 }
+
+#if AXLE_DEBUG_ENABLED
+#define AXLE_ASSERT(cond) (void)(cond);
+#else
+#define AXLE_ASSERT(cond)                                                                          \
+    {                                                                                              \
+        assert(cond);                                                                              \
+    }
+#endif // NDEBUG
 
 } // namespace axle

--- a/src/poller.h
+++ b/src/poller.h
@@ -2,6 +2,8 @@
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include "poller_bsd.h" // IWYU pragma: export
-#endif                  // defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__linux__)
+#include "poller_linux.h" // IWYU pragma: export
+#endif                    // defined(__APPLE__) || defined(__FreeBSD__)
 
 #include "poller_common.h" // IWYU pragma: export

--- a/src/poller_linux.cpp
+++ b/src/poller_linux.cpp
@@ -1,0 +1,424 @@
+#include "poller_linux.h"
+
+#include <signal.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/signalfd.h>
+#include <sys/timerfd.h>
+#include <sys/types.h>
+
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+
+#include <array>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "debug.h"
+#include "poller_common.h"
+
+namespace axle {
+
+namespace {
+
+int signal_procmask(int signo, int action) {
+    // NOLINTNEXTLINE(misc-include-cleaner) -- https://github.com/llvm/llvm-project/issues/120830
+    sigset_t signals{};
+    if (sigemptyset(&signals) == -1) {
+        perror("could not create empty signal set");
+
+        return errno;
+    }
+
+    if (sigaddset(&signals, signo) == -1) {
+        perror("could not add signal to signal set");
+
+        return errno;
+    }
+
+    if (sigprocmask(action, &signals, nullptr) == -1) {
+        perror("could not modify signal mask");
+
+        return errno;
+    }
+
+    return 0;
+}
+
+int signal_block(int signo) {
+    return signal_procmask(signo, SIG_BLOCK);
+}
+
+int signal_unblock(int signo) {
+    return signal_procmask(signo, SIG_UNBLOCK);
+}
+
+PollState drain_fd(int fd, std::span<uint8_t> buf) {
+    const ssize_t ret = read(fd, buf.data(), buf.size());
+    if (ret == -1) {
+        if (errno == EAGAIN) {
+            return PollState::OK;
+        }
+        return PollState::ERR;
+    }
+
+    return (static_cast<size_t>(ret) == buf.size()) ? PollState::OK : PollState::ERR;
+}
+
+} // namespace
+
+Poller::Poller() : poller_fd_(epoll_create1(0)) {
+    if (poller_fd_ == -1) {
+        throw std::runtime_error("failed to initialize epoll poller");
+    }
+}
+
+Poller::~Poller() noexcept {
+    const int ret = close(poller_fd_);
+    if (ret == -1) {
+        perror("failed to close poller file descriptor");
+    }
+}
+
+std::vector<PollOutcome> Poller::poll() const {
+    std::array<struct epoll_event, k_max_event_cnt> evs{};
+
+    const int ret = epoll_wait(poller_fd_, evs.data(), evs.size(), 0);
+    if (ret == -1) {
+        perror("failed to wait for events");
+        return {};
+    }
+    std::vector<PollOutcome> outcomes;
+    outcomes.reserve(ret);
+
+    for (int i = 0; i < ret; ++i) {
+        const struct epoll_event& ev = evs.at(i);
+        const uint32_t events = ev.events;
+        const int fd = ev.data.fd;
+
+        const PollState state = (events & EPOLLERR) != 0 ? PollState::ERR : PollState::OK;
+        if ((events & EPOLLIN) != 0) {
+            if (eventfds_.contains(fd)) {
+                std::array<uint8_t, sizeof(uint64_t)> arr{};
+                const PollState state = drain_fd(fd, std::span{arr});
+                (void)outcomes.emplace_back(fd, PollEvent::USER, state);
+                continue;
+            }
+            if (timerfds_.contains(fd)) {
+                std::array<uint8_t, sizeof(uint64_t)> arr{};
+                const PollState state = drain_fd(fd, std::span{arr});
+                (void)outcomes.emplace_back(fd, PollEvent::TIMER, state);
+                continue;
+            }
+            if (signalfds_.contains(fd)) {
+                std::array<uint8_t, sizeof(struct signalfd_siginfo)> arr{};
+                const PollState state = drain_fd(fd, std::span{arr});
+                (void)outcomes.emplace_back(fd, PollEvent::SIGNAL, state);
+                continue;
+            }
+            (void)outcomes.emplace_back(fd, PollEvent::FD_READ, state);
+            if ((events & EPOLLRDHUP) != 0) {
+                (void)outcomes.emplace_back(fd, PollEvent::FD_EOF, state);
+            }
+        }
+
+        if ((events & EPOLLOUT) != 0) {
+            (void)outcomes.emplace_back(fd, PollEvent::FD_WRITE, state);
+            if ((events & EPOLLRDHUP) != 0) {
+                (void)outcomes.emplace_back(ev.data.fd, PollEvent::FD_EOF, state);
+            }
+        }
+    }
+
+    return outcomes;
+}
+
+int Poller::register_fd_read(int fd) {
+    uint32_t events = 0;
+    int op = EPOLL_CTL_ADD;
+
+    if (fds_.contains(fd)) {
+        events = fds_.at(fd);
+        op = EPOLL_CTL_MOD;
+    }
+    events |= EPOLLIN;
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = events;
+
+    const int ret = epoll_ctl(poller_fd_, op, fd, &ev);
+    if (ret == -1) {
+        perror("failed to register read epoll event for fd");
+
+        return errno;
+    };
+
+    fds_[fd] = events;
+
+    return 0;
+}
+
+int Poller::register_fd_write(int fd) {
+    uint32_t events = 0;
+    int op = EPOLL_CTL_ADD;
+
+    if (fds_.contains(fd)) {
+        events = fds_.at(fd);
+        op = EPOLL_CTL_MOD;
+    }
+    events |= EPOLLOUT;
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = events;
+
+    const int ret = epoll_ctl(poller_fd_, op, fd, &ev);
+    if (ret == -1) {
+        perror("failed to register write epoll event for fd");
+
+        return errno;
+    };
+
+    fds_[fd] = events;
+
+    return 0;
+}
+
+int Poller::register_user_event() {
+    const int fd = eventfd(0, EFD_NONBLOCK);
+    if (fd < 0) {
+        perror("failed to create eventfd");
+        return errno;
+    }
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = EPOLLIN;
+
+    const int ret = epoll_ctl(poller_fd_, EPOLL_CTL_ADD, fd, &ev);
+    if (ret != 0) {
+        perror("failed to register epoll user event");
+        return errno;
+    }
+
+    const bool inserted = eventfds_.emplace(fd).second;
+    AXLE_ASSERT(inserted);
+
+    return fd;
+}
+
+int Poller::register_timer(uint64_t timeout, bool periodic) {
+    // NOLINTNEXTLINE(misc-include-cleaner) -- https://github.com/llvm/llvm-project/issues/64336
+    const int fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
+    if (fd == -1) {
+        perror("failed to create timerfd");
+        return errno;
+    }
+
+    // NOLINTNEXTLINE(misc-include-cleaner) -- https://github.com/llvm/llvm-project/issues/64336
+    struct itimerspec ts = {};
+    ts.it_value.tv_sec = 0;
+    ts.it_value.tv_nsec = static_cast<int64_t>(timeout);
+    ts.it_interval.tv_sec = 0;
+    ts.it_interval.tv_nsec = periodic ? static_cast<int64_t>(timeout) : 0;
+
+    const int ret = timerfd_settime(fd, 0, &ts, nullptr);
+    if (ret == -1) {
+        perror("failed to set time on timerfd");
+
+        return errno;
+    }
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = EPOLLIN;
+
+    const int epoll_ret = epoll_ctl(poller_fd_, EPOLL_CTL_ADD, fd, &ev);
+    if (epoll_ret != 0) {
+        perror("failed to register timer event with epoll");
+
+        return errno;
+    }
+
+    const bool inserted = timerfds_.emplace(fd).second;
+    AXLE_ASSERT(inserted);
+
+    return fd;
+}
+
+int Poller::register_signal(int signo) {
+    sigset_t signals;
+    if (sigemptyset(&signals) == -1) {
+        perror("could not create empty signal set");
+
+        return errno;
+    }
+
+    if (sigaddset(&signals, signo) == -1) {
+        perror("could not add signal to signal set");
+
+        return errno;
+    }
+
+    const int fd = signalfd(-1, &signals, SFD_NONBLOCK);
+    if (fd < 0) {
+        perror("failed to create signalfd");
+
+        return errno;
+    }
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = EPOLLIN;
+
+    const int ret = epoll_ctl(poller_fd_, EPOLL_CTL_ADD, fd, &ev);
+    if (ret != 0) {
+        perror("failed to register signal event with epoll");
+        return errno;
+    }
+
+    const int ret_signal = signal_block(signo);
+    if (ret_signal != 0) {
+        return ret_signal;
+    }
+
+    const bool inserted = signalfds_.insert_or_assign(fd, signo).second;
+    AXLE_ASSERT(inserted);
+
+    return fd;
+}
+
+int Poller::notify_user(int fd) {
+    if (!eventfds_.contains(fd)) {
+        return ENOENT;
+    }
+
+    uint64_t unused = 1;
+    const ssize_t ret = write(fd, &unused, sizeof(unused));
+    if (ret == -1) {
+        return errno;
+    }
+
+    return 0;
+}
+
+int Poller::remove_fd_read(int fd) {
+    uint32_t events = 0;
+
+    if (fds_.contains(fd)) {
+        events = fds_.at(fd);
+    }
+    events &= ~EPOLLIN;
+    const int op = events == 0 ? EPOLL_CTL_DEL : EPOLL_CTL_MOD;
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = events;
+
+    const int ret = epoll_ctl(poller_fd_, op, fd, &ev);
+    if (ret == -1) {
+        perror("failed to fd read event from epoll");
+
+        return errno;
+    };
+
+    if (events == 0) {
+        const size_t num_erased = fds_.erase(fd);
+        AXLE_ASSERT(num_erased == 1);
+    } else {
+        fds_[fd] = events;
+    }
+
+    return 0;
+}
+
+int Poller::remove_fd_write(int fd) {
+    uint32_t events = 0;
+
+    if (fds_.contains(fd)) {
+        events = fds_.at(fd);
+    }
+    events &= ~EPOLLOUT;
+    const int op = events == 0 ? EPOLL_CTL_DEL : EPOLL_CTL_MOD;
+
+    struct epoll_event ev{};
+    ev.data.fd = fd;
+    ev.events = events;
+
+    const int ret = epoll_ctl(poller_fd_, op, fd, &ev);
+    if (ret == -1) {
+        perror("failed to fd read event from epoll");
+
+        return errno;
+    };
+
+    if (events == 0) {
+        const size_t num_erased = fds_.erase(fd);
+        AXLE_ASSERT(num_erased == 1);
+    } else {
+        fds_[fd] = events;
+    }
+
+    return 0;
+}
+
+int Poller::remove_user_event(int id) {
+    const size_t num_erased = eventfds_.erase(id);
+    AXLE_ASSERT(num_erased == 1);
+
+    const int ret = epoll_ctl(poller_fd_, EPOLL_CTL_DEL, id, nullptr);
+    if (ret == -1) {
+        perror("failed to remove user event from epoll");
+
+        return errno;
+    };
+
+    (void)close(id);
+
+    return 0;
+}
+
+int Poller::remove_timer(int id) {
+    const size_t num_erased = timerfds_.erase(id);
+    AXLE_ASSERT(num_erased == 1);
+
+    const int ret = epoll_ctl(poller_fd_, EPOLL_CTL_DEL, id, nullptr);
+    if (ret == -1) {
+        perror("failed to remove timer event from epoll");
+
+        return errno;
+    };
+
+    (void)close(id);
+
+    return 0;
+}
+
+int Poller::remove_signal(int id) {
+    const int signo = signalfds_.at(id);
+    const size_t num_erased = signalfds_.erase(id);
+    AXLE_ASSERT(num_erased == 1);
+
+    const int ret_signal = signal_unblock(signo);
+    if (ret_signal != 0) {
+        return ret_signal;
+    }
+
+    const int ret = epoll_ctl(poller_fd_, EPOLL_CTL_DEL, id, nullptr);
+    if (ret == -1) {
+        perror("failed to remove signal event from epoll");
+
+        return errno;
+    };
+
+    (void)close(id);
+
+    return 0;
+}
+
+} // namespace axle

--- a/src/poller_linux.h
+++ b/src/poller_linux.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <cassert>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace axle {
+
+struct PollOutcome;
+
+class Poller {
+  public:
+    Poller();
+    Poller(const Poller&) = delete;
+    Poller(Poller&&) = delete;
+    Poller& operator=(const Poller&) = delete;
+    Poller& operator=(Poller&&) = delete;
+
+    ~Poller() noexcept;
+
+    std::vector<PollOutcome> poll() const;
+
+    int register_fd_read(int fd);
+    int register_fd_write(int fd);
+    int register_user_event();
+    int register_timer(uint64_t timeout, bool periodic);
+    int register_signal(int signo);
+
+    int notify_user(int fd);
+
+    int remove_fd_read(int fd);
+    int remove_fd_write(int fd);
+    int remove_user_event(int id);
+    int remove_timer(int id);
+    int remove_signal(int id);
+
+  private:
+    static constexpr size_t k_max_event_cnt = 64;
+
+    int poller_fd_;
+    std::unordered_map<int, uint32_t> fds_;
+    std::unordered_set<int> eventfds_;
+    std::unordered_set<int> timerfds_;
+    std::unordered_map<int, int> signalfds_;
+};
+
+} // namespace axle

--- a/src/socket_common.h
+++ b/src/socket_common.h
@@ -4,7 +4,13 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 #include <sys/types.h>
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#define AXLE_USE_SO_NOSIGPIPE
+#endif // MSG_NOSIGNAL
 
 static int do_fcntl(int fd, int cmd, int flags) {
     return fcntl(fd, cmd, flags); // NOLINT(cppcoreguidelines-pro-type-vararg, misc-include-cleaner)
@@ -51,7 +57,12 @@ inline Status<None, int> set_non_blocking(const int fd) {
 }
 
 inline Status<None, int> set_opt_nosigpipe(const int fd) {
+#ifdef AXLE_USE_NOSIGPIPE
     return do_setsockopt(fd, SO_NOSIGPIPE);
+#else
+    (void)fd;
+    return Status<None, int>::make_ok();
+#endif // AXLE_USE_NOSIGPIPE
 }
 
 inline Status<None, int> set_opt_reuseaddr(const int fd) {
@@ -61,7 +72,7 @@ inline Status<None, int> set_opt_reuseaddr(const int fd) {
 inline Status<std::span<const uint8_t>, int> send(const int fd,
                                                   const std::span<const uint8_t> buf) {
     // NOLINTNEXTLINE(misc-include-cleaner) -- for ssize_t
-    const ssize_t len = write(fd, buf.data(), buf.size());
+    const ssize_t len = ::send(fd, buf.data(), buf.size(), MSG_NOSIGNAL);
     if (len == -1) {
         return Status<std::span<const uint8_t>, int>::make_err(errno);
     }


### PR DESCRIPTION
Uses timerfd and signalfd and eventfd for timers, signals and user events, respectively. User events are not exposed via the EventLoop interface and as such remain solely for the shutdown purposes.