### PR TITLE
scheduler: Harden and expand test coverage

### DIFF
--- a/include/axle/scheduler.h
+++ b/include/axle/scheduler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <functional>
 #include <list>
 #include <memory>
@@ -34,6 +36,14 @@ class Scheduler {
     ~Scheduler() = default;
 
   private:
+    enum class State : uint8_t {
+        INITED,
+        RUNNING,
+        SHUTDOWN,
+    };
+
+    static void ensure_inited();
+
     thread_local static Scheduler* k_instance;
 
     static std::mutex k_schedulers_mtx;
@@ -65,7 +75,7 @@ class Scheduler {
     std::unordered_set<std::shared_ptr<Fiber>> blocked_fibers_;
     std::list<std::shared_ptr<Fiber>> terminated_fibers_;
 
-    std::atomic_bool running_;
+    std::atomic<State> state_;
     const std::thread::id host_thread_;
 };
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -69,12 +69,12 @@ void log_dbg(std::format_string<Args...> fmt, Args&&... args) {
 }
 
 #if AXLE_DEBUG_ENABLED
-#define AXLE_ASSERT(cond) (void)(cond);
-#else
 #define AXLE_ASSERT(cond)                                                                          \
     {                                                                                              \
         assert(cond);                                                                              \
     }
+#else
+#define AXLE_ASSERT(cond) (void)(cond);
 #endif // NDEBUG
 
 } // namespace axle

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -25,29 +25,29 @@ std::unordered_map<std::thread::id, std::unique_ptr<Scheduler>> Scheduler::k_sch
 void Scheduler::enter(std::function<void()> entry_point) {
     Scheduler::init();
     k_instance->do_enter(std::move(entry_point));
-    log_dbg("DONE");
+    Scheduler::fini();
 }
 
 void Scheduler::init() {
-    if (k_instance == nullptr) {
-        // Not using `std::make_unique` because `Scheduler`'s constructor is private.
-        // We don't expect to frequent create instances of this class so separating the pointer's
-        // control block from the data block is not an issue.
-        const std::thread::id host_thread = std::this_thread::get_id();
-        {
-            const std::lock_guard<std::mutex> lk{k_schedulers_mtx};
-            std::unique_ptr<Scheduler> scheduler(
-                new Scheduler(std::make_shared<EventLoop>(), host_thread));
-            (void)k_schedulers.emplace(host_thread, std::move(scheduler));
-            k_instance = k_schedulers.at(host_thread).get();
-        }
+    if (k_instance != nullptr) {
+        throw std::runtime_error("scheduler already initialized");
+    }
+
+    // Not using `std::make_unique` because `Scheduler`'s constructor is private.
+    // We don't expect to frequent create instances of this class so separating the pointer's
+    // control block from the data block is not an issue.
+    const std::thread::id host_thread = std::this_thread::get_id();
+    {
+        const std::lock_guard<std::mutex> lk{k_schedulers_mtx};
+        std::unique_ptr<Scheduler> scheduler(
+            new Scheduler(std::make_shared<EventLoop>(), host_thread));
+        (void)k_schedulers.emplace(host_thread, std::move(scheduler));
+        k_instance = k_schedulers.at(host_thread).get();
     }
 }
 
 void Scheduler::fini() {
-    if (k_instance == nullptr) {
-        return;
-    }
+    Scheduler::ensure_inited();
 
     if (k_instance->host_thread_ != std::this_thread::get_id()) {
         return;
@@ -61,6 +61,7 @@ void Scheduler::fini() {
 }
 
 void Scheduler::shutdown() {
+    Scheduler::ensure_inited();
     k_instance->do_shutdown();
 }
 
@@ -72,38 +73,53 @@ void Scheduler::shutdown_all() {
 }
 
 void Scheduler::schedule(std::function<void()> task, std::string tag) {
+    Scheduler::ensure_inited();
     k_instance->do_schedule(std::move(task), std::move(tag));
 }
 
 void Scheduler::run() {
+    Scheduler::ensure_inited();
     k_instance->do_run();
 }
 
 std::shared_ptr<Fiber> Scheduler::current_fiber() {
+    Scheduler::ensure_inited();
     return k_instance->current_fiber_;
 }
 
 void Scheduler::yield() {
+    Scheduler::ensure_inited();
     k_instance->do_yield();
 }
 
 void Scheduler::resume(std::shared_ptr<Fiber> fiber) {
+    Scheduler::ensure_inited();
     (void)k_instance->blocked_fibers_.erase(fiber);
     k_instance->enqueue(std::move(fiber));
 }
 
 std::shared_ptr<EventLoop> Scheduler::get_event_loop() {
+    Scheduler::ensure_inited();
     return k_instance->event_loop_;
+}
+
+void Scheduler::ensure_inited() {
+    if (Scheduler::k_instance == nullptr) {
+        throw std::runtime_error("scheduler is not initialized");
+    }
 }
 
 Scheduler::Scheduler(std::shared_ptr<EventLoop> event_loop, std::thread::id host_thread)
     : main_fiber_{std::make_shared<Fiber>("main")},
       current_fiber_{main_fiber_},
       event_loop_{std::move(event_loop)},
-      running_{false},
+      state_{State::INITED},
       host_thread_{host_thread} {}
 
 void Scheduler::do_schedule(std::function<void()> task, std::string tag) {
+    if (state_ == State::SHUTDOWN) {
+        throw std::runtime_error("scheduler is shutdown");
+    }
     std::shared_ptr<Fiber> fiber = std::make_shared<Fiber>(
         [this, task = std::move(task)]() {
             task();
@@ -115,7 +131,7 @@ void Scheduler::do_schedule(std::function<void()> task, std::string tag) {
 }
 
 void Scheduler::do_yield() {
-    if (!running_) {
+    if (state_ != State::RUNNING) {
         throw std::runtime_error("scheduler is not running");
     }
     log_dbg("YIELD  {}", Scheduler::current_fiber());
@@ -124,7 +140,7 @@ void Scheduler::do_yield() {
 }
 
 void Scheduler::do_fini() {
-    log_dbg("FINI   {}", Scheduler::current_fiber());
+    log_dbg("FINI");
     for (auto&& blocked_fiber : blocked_fibers_) {
         log_dbg("BLOCKD {}", blocked_fiber);
         enqueue(blocked_fiber);
@@ -135,37 +151,48 @@ void Scheduler::do_fini() {
     // get a chance to run. Therefore, we enqueue all blocked fibers and then interrupt each fiber
     // just before resuming its execution.
     while (!ready_fibers_.empty()) {
-        std::shared_ptr<Fiber> target = std::move(ready_fibers_.back());
-        ready_fibers_.pop_back();
+        std::shared_ptr<Fiber> target = std::move(ready_fibers_.front());
+        ready_fibers_.pop_front();
         log_dbg("INTRPT {}", target);
         target->interrupt();
         switch_to(std::move(target));
     }
 
     while (!terminated_fibers_.empty()) {
-        terminated_fibers_.pop_back();
+        terminated_fibers_.pop_front();
     }
 }
 
 void Scheduler::do_enter(std::function<void()> entry_point) {
     log_dbg("ENTER");
-    do_schedule(std::move(entry_point), "entry_point");
-    const Status<int, int> status = event_loop_->register_signal(SIGINT, [&](auto status) {
+    do_schedule(
+        [&, entry_point = std::move(entry_point)] {
+            entry_point();
+            do_shutdown();
+        },
+        "entry_point");
+    Status<int, int> reg_status = event_loop_->register_signal(SIGINT, [&](auto status) {
         (void)status;
-        do_schedule([&] { do_shutdown(); }, "shutdown");
+        do_shutdown();
     });
 
-    if (status.is_err()) {
+    if (reg_status.is_err()) {
         throw std::runtime_error("could not register shutdown signal handler with event loop");
     }
+    const int shutdown_handler_id = reg_status.ok();
 
     do_run();
-    do_fini();
+    // We are here because `do_shutdown` has been called which causes `do_run` to return. We can now
+    // remove the signal handler.
+    Status<None, int> rem_status = event_loop_->remove_signal(shutdown_handler_id);
+    if (rem_status.is_err()) {
+        (void)rem_status.err();
+    }
 }
 
 void Scheduler::do_shutdown() {
-    // log_dbg("SHUTDN {}", Scheduler::current_fiber());
-    running_.store(false);
+    log_dbg("SHUTDN");
+    state_ = State::SHUTDOWN;
 }
 
 void Scheduler::enqueue(std::shared_ptr<Fiber> fiber) {
@@ -174,17 +201,17 @@ void Scheduler::enqueue(std::shared_ptr<Fiber> fiber) {
 }
 
 void Scheduler::do_run() {
-    running_.store(true);
+    state_ = State::RUNNING;
 
-    while (running_) {
+    while (state_ == State::RUNNING) {
         while (!ready_fibers_.empty()) {
-            std::shared_ptr<Fiber> target = std::move(ready_fibers_.back());
-            ready_fibers_.pop_back();
+            std::shared_ptr<Fiber> target = std::move(ready_fibers_.front());
+            ready_fibers_.pop_front();
             switch_to(std::move(target));
         }
 
         while (!terminated_fibers_.empty()) {
-            terminated_fibers_.pop_back();
+            terminated_fibers_.pop_front();
         }
 
         event_loop_->tick();

--- a/test/scheduler_test.cpp
+++ b/test/scheduler_test.cpp
@@ -2,8 +2,13 @@
 
 #include "axle/scheduler.h"
 
+#include <csignal>
+
+#include <exception>
 #include <stdexcept>
 #include <thread>
+
+#include "fiber.h" // IWYU pragma: keep
 
 #include "gtest/gtest.h"
 
@@ -20,7 +25,116 @@ void maybe_shutdown(const T& a, const T& a_lim) {
 
 } // namespace
 
-TEST(SchedulerTest, RunTasks) {
+TEST(SchedulerTest, EnterRunsEntryPoint) {
+    bool ran = false;
+    Scheduler::enter([&] { ran = true; });
+    ASSERT_TRUE(ran);
+}
+
+TEST(SchedulerTest, EnterFromMultipleThreads) {
+    int a = 0;
+    int b = 0;
+
+    std::thread t1([&] { Scheduler::enter([&] { a = 1; }); });
+    std::thread t2([&] { Scheduler::enter([&] { b = 2; }); });
+
+    t1.join();
+    t2.join();
+
+    ASSERT_EQ(1, a);
+    ASSERT_EQ(2, b);
+}
+
+TEST(SchedulerTest, EnterNestedScheduling) {
+    bool entry_point_ran = false;
+    bool entry_point_eintr = false;
+    bool inner_ran = false;
+    bool inner_eintr = false;
+
+    Scheduler::enter([&] {
+        Scheduler::schedule(
+            [&] {
+                inner_ran = true;
+                inner_eintr = Scheduler::current_fiber()->interrupted();
+            },
+            "inner");
+        entry_point_ran = true;
+        entry_point_eintr = Scheduler::current_fiber()->interrupted();
+    });
+    ASSERT_TRUE(entry_point_ran);
+    ASSERT_FALSE(entry_point_eintr);
+    ASSERT_TRUE(inner_ran);
+    ASSERT_FALSE(inner_eintr);
+}
+
+TEST(SchedulerTest, EnterDoubleNesting) {
+    bool entry_point_ran = false;
+    bool entry_point_eintr = false;
+    bool outer_ran = false;
+    bool outer_eintr = false;
+    bool inner_ran = false;
+
+    Scheduler::enter([&] {
+        Scheduler::schedule(
+            [&] {
+                outer_ran = true;
+                outer_eintr = Scheduler::current_fiber()->interrupted();
+                ASSERT_THROW(Scheduler::schedule([&] { inner_ran = true; }, "inner"),
+                             std::runtime_error);
+            },
+            "outer");
+        entry_point_ran = true;
+        entry_point_eintr = Scheduler::current_fiber()->interrupted();
+    });
+
+    ASSERT_TRUE(entry_point_ran);
+    ASSERT_FALSE(entry_point_eintr);
+    ASSERT_TRUE(outer_ran);
+    ASSERT_FALSE(outer_eintr);
+    ASSERT_FALSE(inner_ran);
+}
+
+TEST(SchedulerTest, EnterAfterSchedule) {
+    bool adhoc_ran = false;
+    bool entry_point_ran = false;
+
+    Scheduler::init();
+    Scheduler::schedule([&] { adhoc_ran = true; }, "adhoc");
+    ASSERT_THROW(Scheduler::enter([&] { entry_point_ran = true; }), std::runtime_error);
+    ASSERT_FALSE(adhoc_ran); // Doesn't run in the context of `Scheduler::enter`
+    Scheduler::fini();
+
+    ASSERT_FALSE(entry_point_ran);
+    ASSERT_TRUE(adhoc_ran); // Runs in the context of the `Scheduler::fini`
+}
+
+TEST(SchedulerTest, InitWorks) {
+    ASSERT_NO_THROW(Scheduler::init());
+    Scheduler::fini();
+}
+
+TEST(SchedulerTest, InitTwiceFails) {
+    Scheduler::init();
+    ASSERT_THROW(Scheduler::init(), std::runtime_error);
+    Scheduler::fini();
+}
+
+TEST(SchedulerTest, FiniWorks) {
+    Scheduler::init();
+    ASSERT_NO_THROW(Scheduler::fini());
+}
+
+TEST(SchedulerTest, FiniWithoutInit) {
+    ASSERT_THROW(Scheduler::fini(), std::runtime_error);
+}
+
+TEST(SchedulerTest, FiniTwice) {
+    Scheduler::init();
+    ASSERT_NO_THROW(Scheduler::fini());
+    ASSERT_THROW(Scheduler::fini(), std::runtime_error);
+}
+
+TEST(SchedulerTest, ScheduleWorks) {
     int a = 0;
     Scheduler::init();
 
@@ -40,11 +154,11 @@ TEST(SchedulerTest, RunTasks) {
     ASSERT_EQ(3, a);
 }
 
-TEST(SchedulerTest, NoInit) {
-    ASSERT_DEATH(Scheduler::schedule([] {}), "");
+TEST(SchedulerTest, ScheduleNoInit) {
+    ASSERT_THROW(Scheduler::schedule([] {}), std::runtime_error);
 }
 
-TEST(SchedulerTest, NestedScheduling) {
+TEST(SchedulerTest, ScheduleNested) {
     int a = 0;
     Scheduler::init();
 
@@ -62,7 +176,7 @@ TEST(SchedulerTest, NestedScheduling) {
     ASSERT_EQ(2, a);
 }
 
-TEST(SchedulerTest, ManyTasks) {
+TEST(SchedulerTest, ScheduleManyTasks) {
     constexpr int task_cnt = 10000;
     int a = 0;
     Scheduler::init();
@@ -80,7 +194,7 @@ TEST(SchedulerTest, ManyTasks) {
     ASSERT_EQ(task_cnt, a);
 }
 
-TEST(SchedulerTest, Multithreaded) {
+TEST(SchedulerTest, ScheduleMultithreaded) {
     constexpr int task_cnt_a = 10000;
     constexpr int task_cnt_b = 5000;
     int a = 0;
@@ -119,6 +233,18 @@ TEST(SchedulerTest, Multithreaded) {
     ASSERT_EQ(task_cnt_b, b);
 }
 
+TEST(SchedulerTest, ScheduleTaskThrows) {
+    ASSERT_EXIT(
+        {
+            Scheduler::init();
+            Scheduler::schedule([] { throw std::exception{}; }, "my-task");
+            Scheduler::run();
+            Scheduler::fini();
+        },
+        testing::KilledBySignal(SIGABRT),
+        ".*");
+}
+
 TEST(SchedulerTest, YieldBeforeRun) {
     int a = 0;
     Scheduler::init();
@@ -129,6 +255,34 @@ TEST(SchedulerTest, YieldBeforeRun) {
     });
 
     ASSERT_THROW(Scheduler::yield(), std::runtime_error);
+    Scheduler::fini();
+}
+
+// TODO (whalbawi): Enable this test once yielding pushes the fiber back into the ready queue
+TEST(SchedulerTest, DISABLED_YieldWorks) {
+    int a = 0;
+    int b = 0;
+    Scheduler::init();
+
+    Scheduler::schedule([&] {
+        a++;
+        ASSERT_EQ(1, a);
+        Scheduler::yield();
+        a++;
+    });
+
+    Scheduler::schedule([&] {
+        b++;
+        ASSERT_EQ(1, b);
+        Scheduler::yield();
+        b++;
+        Scheduler::shutdown();
+    });
+
+    Scheduler::run();
+
+    ASSERT_EQ(2, a);
+    ASSERT_EQ(2, b);
     Scheduler::fini();
 }
 


### PR DESCRIPTION
Hardens scheduling semantics and ensures that failures are communicated clearly. Some major changes:
- Fibers are processed FIFO.
- Shutdown handler runs in the context of the entry_point fiber rather than in a separate scheduled one.