### PR TITLE
socket: Expand test coverage

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,9 +28,9 @@ IncludeCategories:
     Priority:        1
     SortPriority:    1
   - Regex:           '^<[a-z]+/.*\.h>'                 # <sys/event.h>
-    SortPriority:    2
     Priority:        1
-  - Regex:           '^<c(assert,errno|signal|string|std).*>' # <cstring>
+    SortPriority:    2
+  - Regex:           '^<c(assert|errno|signal|string|std).*>' # <cstring>
     Priority:        2
     SortPriority:    3
   - Regex:           '^<.*/'                           # <a/other>
@@ -40,17 +40,20 @@ IncludeCategories:
     Priority:        3
     SortPriority:    4
   - Regex:           '^"gtest/.*"'                     # "gtest/gtest.h"
-    SortPriority:    8
     Priority:        5
-  - Regex:           '^"benchmark/.*"'                 # "gtest/gtest.h"
-    SortPriority:    9
+    SortPriority:    8
+  - Regex:           '^"test_.*"'                     # "test_common.h"
     Priority:        6
+    SortPriority:    9
+  - Regex:           '^"benchmark/.*"'                 # "benchmark/benchmark.h"
+    Priority:        7
+    SortPriority:   10
   - Regex:           '^".*/'                           # "b/project"
+    Priority:        4
     SortPriority:    7
-    Priority:        4
   - Regex:           '^".*"'                           # "project"
-    SortPriority:    6
     Priority:        4
+    SortPriority:    6
 
 ---
 Language: Json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ endif ()
 
 # Test files
 set(AXLE_TEST_LIST
+    ${AXLE_TEST_DIR}/async_socket_test.cpp
     ${AXLE_TEST_DIR}/axle_test.cpp
     ${AXLE_TEST_DIR}/event_test.cpp
     ${AXLE_TEST_DIR}/fiber_test.cpp
@@ -132,7 +133,7 @@ endif()
 
 # Unit tests
 add_executable(axle_test ${AXLE_TEST_LIST})
-target_include_directories(axle_test PRIVATE ${AXLE_SRC_DIR})
+target_include_directories(axle_test PRIVATE ${AXLE_SRC_DIR} ${AXLE_TEST_DIR})
 target_link_libraries(axle_test axle gtest_main)
 
 add_test(unit-tests axle_test)

--- a/src/async_socket.cpp
+++ b/src/async_socket.cpp
@@ -5,6 +5,7 @@
 
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "fiber.h" // IWYU pragma: keep
@@ -15,13 +16,17 @@
 
 namespace axle {
 
-AsyncSocket::AsyncSocket() : AsyncSocket(socket::create_tcp()) {}
+AsyncSocket::AsyncSocket()
+    : AsyncSocket([] {
+          Status fd_status = socket::create_tcp();
+          if (fd_status.is_err()) {
+              throw std::runtime_error{"could not create TCP socket"};
+          }
+
+          return fd_status.ok();
+      }()) {}
 
 AsyncSocket::AsyncSocket(int fd) : event_loop_(Scheduler::get_event_loop()), fd_(fd) {
-    if (fd_ == -1) {
-        throw std::runtime_error("invalid socket fd");
-    }
-
     if (socket::set_non_blocking(fd_).is_err()) {
         (void)close();
 
@@ -64,6 +69,7 @@ Status<None, int> AsyncSocket::send_all(std::span<const uint8_t> buf_view) const
                 return Err(ev_status.err());
             }
             Scheduler::yield();
+            (void)event_loop_->remove_fd_write(get_fd());
             if (Scheduler::current_fiber()->interrupted()) {
                 (void)event_loop_->remove_fd_write(get_fd());
                 return Err(EINTR);
@@ -97,6 +103,7 @@ Status<std::span<uint8_t>, int> AsyncSocket::recv_some(std::span<uint8_t> buf_vi
                 return Err(ev_status.err());
             }
             Scheduler::yield();
+            (void)event_loop_->remove_fd_read(get_fd());
             if (Scheduler::current_fiber()->interrupted()) {
                 (void)event_loop_->remove_fd_read(get_fd());
                 return Err(EINTR);
@@ -127,6 +134,50 @@ Status<None, int> AsyncSocket::close() {
 
 int AsyncSocket::get_fd() const {
     return fd_;
+}
+
+Status<None, int> AsyncClientSocket::connect(const std::string& address, int port) const {
+    for (;;) {
+        Status<None, int> connect_status = socket::connect(get_fd(), address, port);
+        if (connect_status.is_ok()) {
+            return Ok();
+        }
+
+        const int err = connect_status.err();
+        switch (err) {
+        case EINPROGRESS: {
+            Status<None, int> ev_status = event_loop_->register_fd_write(
+                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t> status) {
+                    (void)status;
+                    Scheduler::resume(fiber);
+                });
+            if (ev_status.is_err()) {
+                return Err(ev_status.err());
+            }
+
+            Scheduler::yield();
+            (void)event_loop_->remove_fd_write(get_fd());
+            if (Scheduler::current_fiber()->interrupted()) {
+                return Err(EINTR);
+            }
+
+            Status sockopt = socket::get_error(get_fd());
+            if (sockopt.is_err()) {
+                return Err(sockopt.err());
+            }
+
+            const int sockerr = sockopt.ok();
+            if (sockerr != 0) {
+                return Err(sockerr);
+            }
+
+            return Ok();
+        }
+
+        default:
+            return Err(err);
+        }
+    }
 }
 
 AsyncServerSocket::AsyncServerSocket() {

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -12,13 +12,17 @@
 
 namespace axle {
 
-Socket::Socket() : Socket(socket::create_tcp()) {}
+Socket::Socket()
+    : Socket([] {
+          Status fd_status = socket::create_tcp();
+          if (fd_status.is_err()) {
+              throw std::runtime_error{"could not create TCP socket"};
+          }
+
+          return fd_status.ok();
+      }()) {}
 
 Socket::Socket(int fd) : fd_(fd) {
-    if (fd_ == -1) {
-        throw std::runtime_error("invalid socket fd");
-    }
-
     if (socket::set_opt_nosigpipe(fd_).is_err()) {
         (void)close();
 

--- a/src/socket_common.h
+++ b/src/socket_common.h
@@ -8,8 +8,10 @@
 #include <sys/types.h>
 
 #include <cerrno>
+#include <cstdio>
 
 #include <span>
+#include <string>
 
 #include "axle/status.h"
 
@@ -18,45 +20,97 @@
 #define AXLE_USE_SO_NOSIGPIPE
 #endif // MSG_NOSIGNAL
 
-static int do_fcntl(int fd, int cmd, int flags) {
-    return fcntl(fd, cmd, flags); // NOLINT(cppcoreguidelines-pro-type-vararg, misc-include-cleaner)
+namespace axle::socket {
+
+namespace detail {
+
+inline Status<int, int> do_fcntl(int fd, int cmd, int flags) {
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    const int ret = ::fcntl(fd, cmd, flags);
+    if (ret == -1) {
+        const int err = errno;
+        perror("fcntl");
+
+        return Err(err);
+    }
+
+    return Ok(ret);
 }
 
-static struct sockaddr* endpoint_to_sockaddr(const std::string& address,
+inline struct sockaddr* endpoint_to_sockaddr(const std::string& address,
                                              int port,
                                              struct sockaddr_in& addr_in) {
     addr_in.sin_family = AF_INET;
-    addr_in.sin_port = htons(port); // NOLINT(misc-include-cleaner)
+    addr_in.sin_port = htons(port);
     addr_in.sin_addr.s_addr = inet_addr(address.c_str());
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return reinterpret_cast<struct sockaddr*>(&addr_in);
 }
 
-static axle::Status<axle::None, int> do_setsockopt(const int fd, int opt) {
-    int enable = 1;
-    if (setsockopt(fd, SOL_SOCKET, opt, &enable, sizeof(enable)) == -1) {
-        return axle::Err(errno);
+template <typename T>
+inline Status<T, int> do_getgetopt(const int fd, int opt) {
+    T val = {};
+    socklen_t val_sz = static_cast<socklen_t>(sizeof(val));
+
+    if (::getsockopt(fd, SOL_SOCKET, opt, &val, &val_sz) == -1) {
+        const int err = errno;
+        perror("getsockopt");
+
+        return Err(err);
     }
 
-    return axle::Ok();
+    return Ok(val);
 }
 
-namespace axle::socket {
+inline Status<None, int> do_setsockopt(const int fd, int opt) {
+    int enable = 1;
+    if (::setsockopt(fd, SOL_SOCKET, opt, &enable, sizeof(enable)) == -1) {
+        const int err = errno;
+        perror("setsockopt");
 
-inline int create_tcp() {
-    return ::socket(AF_INET, SOCK_STREAM, 0);
+        return Err(err);
+    }
+
+    return Ok();
+}
+
+} // namespace detail
+
+inline Status<int, int> create_tcp() {
+    const int ret = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (ret == -1) {
+        const int err = errno;
+        perror("socket");
+
+        return Err(err);
+    }
+
+    return Ok(ret);
+}
+
+inline Status<size_t, int> get_sndbuf_sz(const int fd) {
+    return detail::do_getgetopt<size_t>(fd, SO_SNDBUF);
+}
+
+inline Status<size_t, int> get_rcvbuf_sz(const int fd) {
+    return detail::do_getgetopt<size_t>(fd, SO_RCVBUF);
+}
+
+inline Status<int, int> get_error(const int fd) {
+    return detail::do_getgetopt<int>(fd, SO_ERROR);
 }
 
 inline Status<None, int> set_non_blocking(const int fd) {
-    const int flags = do_fcntl(fd, F_GETFL, 0); // NOLINT(misc-include-cleaner) -- for F_GETFL
-    if (flags == -1) {
-        return Err(errno);
+    Status flags = detail::do_fcntl(fd, F_GETFL, 0);
+    if (flags.is_err()) {
+        return Err(flags.err());
     }
 
-    // NOLINTNEXTLINE(misc-include-cleaner) -- for F_SETFL, O_NONBLOCK
-    if (do_fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
-        return Err(errno);
+    Status status = detail::do_fcntl(fd, F_SETFL, flags.ok() | O_NONBLOCK);
+    if (status.is_err()) {
+        return Err(status.err());
     }
 
     return Ok();
@@ -64,7 +118,7 @@ inline Status<None, int> set_non_blocking(const int fd) {
 
 inline Status<None, int> set_opt_nosigpipe(const int fd) {
 #ifdef AXLE_USE_NOSIGPIPE
-    return do_setsockopt(fd, SO_NOSIGPIPE);
+    return detail::do_setsockopt(fd, SO_NOSIGPIPE);
 #else
     (void)fd;
     return Ok();
@@ -72,24 +126,29 @@ inline Status<None, int> set_opt_nosigpipe(const int fd) {
 }
 
 inline Status<None, int> set_opt_reuseaddr(const int fd) {
-    return do_setsockopt(fd, SO_REUSEADDR);
+    return detail::do_setsockopt(fd, SO_REUSEADDR);
 }
 
 inline Status<std::span<const uint8_t>, int> send(const int fd,
                                                   const std::span<const uint8_t> buf) {
-    // NOLINTNEXTLINE(misc-include-cleaner) -- for ssize_t
     const ssize_t len = ::send(fd, buf.data(), buf.size(), MSG_NOSIGNAL);
     if (len == -1) {
-        return Err(errno);
+        const int err = errno;
+        perror("send");
+
+        return Err(err);
     }
 
     return Ok(buf.subspan(len));
 }
 
 inline Status<std::span<uint8_t>, int> recv(const int fd, const std::span<uint8_t> buf) {
-    const ssize_t len = read(fd, buf.data(), buf.size());
+    const ssize_t len = ::read(fd, buf.data(), buf.size());
     if (len == -1) {
-        return Err(errno);
+        const int err = errno;
+        perror("read");
+
+        return Err(err);
     }
 
     return Ok(buf.first(len));
@@ -97,13 +156,19 @@ inline Status<std::span<uint8_t>, int> recv(const int fd, const std::span<uint8_
 
 inline Status<None, int> listen(const int fd, const int port, const int backlog) {
     struct sockaddr_in addr_in{};
-    struct sockaddr* addr = endpoint_to_sockaddr("0.0.0.0", port, addr_in);
-    if (bind(fd, addr, sizeof(*addr)) == -1) {
-        return Err(errno);
+    struct sockaddr* addr = detail::endpoint_to_sockaddr("0.0.0.0", port, addr_in);
+    if (::bind(fd, addr, sizeof(*addr)) == -1) {
+        const int err = errno;
+        perror("bind");
+
+        return Err(err);
     }
 
     if (::listen(fd, backlog) < 0) {
-        return Err(errno);
+        const int err = errno;
+        perror("listen");
+
+        return Err(err);
     }
 
     return Ok();
@@ -112,7 +177,10 @@ inline Status<None, int> listen(const int fd, const int port, const int backlog)
 inline Status<int, int> accept(const int fd) {
     const int peer_fd = ::accept(fd, nullptr, nullptr);
     if (peer_fd == -1) {
-        return Err(errno);
+        const int err = errno;
+        perror("accept");
+
+        return Err(err);
     }
 
     return Ok(peer_fd);
@@ -120,10 +188,13 @@ inline Status<int, int> accept(const int fd) {
 
 inline Status<None, int> connect(const int fd, const std::string& address, const int port) {
     struct sockaddr_in addr_in{};
-    struct sockaddr* addr = endpoint_to_sockaddr(address, port, addr_in);
+    struct sockaddr* addr = detail::endpoint_to_sockaddr(address, port, addr_in);
 
     if (::connect(fd, addr, sizeof(*addr)) == -1) {
-        return Err(errno);
+        const int err = errno;
+        perror("connect");
+
+        return Err(err);
     }
 
     return Ok();
@@ -131,7 +202,10 @@ inline Status<None, int> connect(const int fd, const std::string& address, const
 
 inline Status<None, int> close(const int fd) {
     if (fd != -1 && ::close(fd) == -1) {
-        return Err(errno);
+        const int err = errno;
+        perror("close");
+
+        return Err(err);
     }
 
     return Ok();

--- a/test/async_socket_test.cpp
+++ b/test/async_socket_test.cpp
@@ -1,0 +1,663 @@
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+#include "axle/async_socket.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "socket_common.h"
+#include "axle/scheduler.h"
+#include "axle/socket.h"
+#include "axle/status.h"
+
+#include "gtest/gtest.h"
+
+#include "test_common.h"
+
+namespace axle {
+
+namespace {
+
+constexpr int k_test_port_base = 9000;
+constexpr int k_listen_backlog = 8;
+constexpr size_t k_buf_sz = 4096;
+
+int test_port() {
+    static std::atomic<int> counter{0};
+    return k_test_port_base + counter.fetch_add(1);
+}
+
+class Server {
+  public:
+    explicit Server(int port) : port_(port) {}
+    Server(const Server&) = delete;
+    Server(const Server&&) = delete;
+    Server& operator=(const Server&) = delete;
+    Server& operator=(Server&&) = delete;
+
+    void start() {
+        thread_ = std::thread([this] { run(); });
+        {
+            std::unique_lock lk{mtx_};
+            cv_ready_.wait(lk, [this] { return ready_; });
+        }
+    }
+
+    void join() {
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    virtual ~Server() {
+        join();
+    }
+
+  private:
+    virtual void connection_handler(Socket client) = 0;
+
+    void run() {
+        const axle::ServerSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.listen(port_, k_listen_backlog));
+        {
+            const std::lock_guard lk{mtx_};
+            ready_ = true;
+            cv_ready_.notify_one();
+        }
+
+        Status<Socket, int> accept = socket.accept();
+        AXLE_TEST_ASSERT_OK(accept);
+        Socket client = accept.ok();
+
+        connection_handler(std::move(client));
+    }
+
+    int port_;
+    std::thread thread_;
+
+    std::mutex mtx_;
+    bool ready_ = false;
+    std::condition_variable cv_ready_;
+};
+
+class EchoServer : public Server {
+  public:
+    explicit EchoServer(int port) : Server(port) {}
+
+  private:
+    void connection_handler(Socket client) override {
+        for (;;) {
+            std::array<uint8_t, k_buf_sz> buf{};
+            Status<std::span<uint8_t>, int> recv = client.recv_some(std::span(buf));
+            ASSERT_TRUE(recv.is_ok());
+            const std::span<uint8_t> recv_buf = recv.ok();
+
+            if (recv_buf.empty()) {
+                ASSERT_TRUE(client.close().is_ok());
+                break;
+            }
+
+            const Status<None, int> send = client.send_all(recv_buf);
+            ASSERT_TRUE(send.is_ok());
+        }
+    }
+};
+
+class RecvServer : public Server {
+  public:
+    RecvServer(int port, std::span<uint8_t> payload) : Server(port), payload_(payload) {}
+
+  private:
+    virtual void before_recv() {};
+    virtual void before_close() {};
+
+    void connection_handler(Socket client) override {
+        before_recv();
+        for (std::span<uint8_t> view = payload_; !view.empty();) {
+            Status<std::span<uint8_t>, int> recv = client.recv_some(view);
+            AXLE_TEST_ASSERT_OK(recv);
+            const std::span<uint8_t> recv_view = recv.ok();
+
+            if (recv_view.empty()) {
+                break;
+            }
+
+            view = view.subspan(recv_view.size());
+        }
+
+        before_close();
+        AXLE_TEST_ASSERT_OK(client.close());
+    }
+
+    std::span<uint8_t> payload_;
+};
+
+class RecvOnSignalServer : public RecvServer {
+  public:
+    RecvOnSignalServer(int port, std::span<uint8_t> payload) : RecvServer(port, payload) {}
+
+    void signal_recv() {
+        {
+            const std::lock_guard<std::mutex> lk{mtx_};
+            signaled_recv_ = true;
+            cv_recv_.notify_one();
+        }
+    }
+
+    void signal_close() {
+        {
+            const std::lock_guard<std::mutex> lk{mtx_};
+            signaled_close_ = true;
+            cv_close_.notify_one();
+        }
+    }
+
+  private:
+    void before_recv() override {
+        {
+            std::unique_lock<std::mutex> lk{mtx_};
+            cv_recv_.wait(lk, [&] { return signaled_recv_.load(); });
+        }
+    }
+
+    void before_close() override {
+        {
+            std::unique_lock<std::mutex> lk{mtx_};
+            cv_close_.wait(lk, [&] { return signaled_close_.load(); });
+        }
+    }
+
+    std::mutex mtx_;
+    std::condition_variable cv_recv_;
+    std::condition_variable cv_close_;
+    std::atomic_bool signaled_recv_;
+    std::atomic_bool signaled_close_;
+};
+
+class SendServer : public Server {
+  public:
+    SendServer(int port, std::span<uint8_t> payload) : Server(port), payload_(payload) {}
+
+  private:
+    virtual void before_send() {};
+    virtual void before_close() {};
+
+    void connection_handler(Socket client) override {
+        before_send();
+        AXLE_TEST_ASSERT_OK(client.send_all(payload_));
+        before_close();
+        AXLE_TEST_ASSERT_OK(client.close());
+    }
+
+    std::span<uint8_t> payload_;
+};
+
+class SendOnSignalServer : public SendServer {
+  public:
+    SendOnSignalServer(int port, std::span<uint8_t> payload) : SendServer(port, payload) {}
+
+    void signal_send() {
+        {
+            const std::lock_guard<std::mutex> lk{mtx_};
+            signaled_send_ = true;
+            cv_send_.notify_one();
+        }
+    }
+
+    void signal_close() {
+        {
+            const std::lock_guard<std::mutex> lk{mtx_};
+            signaled_close_ = true;
+            cv_close_.notify_one();
+        }
+    }
+
+  private:
+    void before_send() override {
+        {
+            std::unique_lock<std::mutex> lk{mtx_};
+            cv_send_.wait(lk, [&] { return signaled_send_.load(); });
+        }
+    }
+
+    void before_close() override {
+        {
+            std::unique_lock<std::mutex> lk{mtx_};
+            cv_close_.wait(lk, [&] { return signaled_close_.load(); });
+        }
+    }
+
+    std::mutex mtx_;
+    std::condition_variable cv_send_;
+    std::condition_variable cv_close_;
+    std::atomic_bool signaled_send_;
+    std::atomic_bool signaled_close_;
+};
+
+class ResetServer : public Server {
+  public:
+    explicit ResetServer(int port) : Server(port) {}
+
+  private:
+    virtual void before_close() {}
+
+    void connection_handler(Socket client) override {
+        before_close();
+        AXLE_TEST_ASSERT_OK(client.close());
+    }
+};
+
+class ResetOnSignalServer : public ResetServer {
+  public:
+    explicit ResetOnSignalServer(int port) : ResetServer(port) {}
+
+    void signal_close() {
+        {
+            const std::lock_guard<std::mutex> lk{mtx_};
+            signaled_close_ = true;
+            cv_close_.notify_one();
+        }
+    }
+
+  private:
+    void before_close() override {
+        {
+            std::unique_lock<std::mutex> lk{mtx_};
+            cv_close_.wait(lk, [&] { return signaled_close_.load(); });
+        }
+    }
+
+    std::mutex mtx_;
+    std::condition_variable cv_close_;
+    std::atomic_bool signaled_close_;
+};
+
+} // namespace
+
+TEST(AsyncSocketTest, SendRecvEcho) {
+    const int port = test_port();
+    EchoServer server{port};
+
+    server.start();
+    Scheduler::enter([&] {
+        const AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+        std::array<uint8_t, k_buf_sz> send_buf{};
+        rnd_buf(send_buf);
+
+        AXLE_TEST_ASSERT_OK(socket.send_all(send_buf));
+
+        std::array<uint8_t, k_buf_sz> recv_buf{};
+        for (std::span<uint8_t> view{recv_buf}; !view.empty();) {
+            Status<std::span<uint8_t>, int> recv = socket.recv_some(view);
+            AXLE_TEST_ASSERT_OK(recv);
+            const std::span<uint8_t> recv_view = recv.ok();
+            if (recv_view.empty()) {
+                break;
+            }
+
+            view = view.subspan(recv_view.size());
+        }
+
+        ASSERT_EQ(recv_buf, send_buf);
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+TEST(AsyncSocketTest, SendAllBackpressure) {
+    Status fd_status = socket::create_tcp();
+    AXLE_TEST_ASSERT_OK(fd_status);
+
+    const int fd = fd_status.ok();
+
+    // Send a large buffer so that `send_all` blocks
+    Status<size_t, int> sndbuf_sz_status = socket::get_sndbuf_sz(fd);
+    AXLE_TEST_ASSERT_OK(sndbuf_sz_status);
+    const size_t send_buf_sz = sndbuf_sz_status.ok();
+
+    Status<size_t, int> rcvbuf_sz_status = socket::get_rcvbuf_sz(fd);
+    AXLE_TEST_ASSERT_OK(rcvbuf_sz_status);
+    const size_t recv_buf_sz = rcvbuf_sz_status.ok();
+
+    const size_t buf_sz = 2 * (recv_buf_sz + send_buf_sz);
+
+    const int port = test_port();
+    std::vector<uint8_t> payload(buf_sz);
+
+    RecvServer server{port, payload};
+    server.start();
+
+    Scheduler::enter([fd, port, buf_sz, &payload, &server] {
+        AXLE_TEST_ASSERT_OK(socket::connect(fd, "127.0.0.1", port));
+        AsyncSocket socket{fd};
+
+        std::vector<uint8_t> buf;
+        buf.resize(buf_sz);
+        rnd_buf(buf);
+        AXLE_TEST_ASSERT_OK(socket.send_all(buf));
+
+        std::array<uint8_t, 1> eof{};
+        Status recv = socket.recv_some(eof);
+        AXLE_TEST_ASSERT_OK(recv);
+
+        server.join();
+        ASSERT_EQ(payload, buf);
+        ASSERT_TRUE(recv.ok().empty());
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+
+        Scheduler::shutdown();
+    });
+}
+
+TEST(AsyncClientSocketTest, ConnectSuccess) {
+    const int port = test_port();
+    ResetServer server{port};
+
+    server.start();
+    Scheduler::enter([port] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        std::array<uint8_t, 1> buf{};
+        const std::span<uint8_t> buf_view{buf};
+        Status<std::span<uint8_t>, int> recv = socket.recv_some(buf_view);
+        AXLE_TEST_ASSERT_OK(recv);
+        ASSERT_TRUE(recv.ok().empty());
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+TEST(AsyncClientSocketTest, ConnectRefused) {
+    Scheduler::enter([] {
+        AsyncClientSocket socket{};
+        ASSERT_TRUE(socket.connect("127.0.0.1", 1234).is_err());
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+}
+
+TEST(AsyncClientSocketTest, ServerNonBlockingSendAndClose) {
+    const int port = test_port();
+    std::array<uint8_t, k_buf_sz> payload{};
+    rnd_buf(payload);
+    SendOnSignalServer server{port, payload};
+    server.start();
+    // Have the server send the payload and close the socket before the call to `recv_some` below.
+    server.signal_send();
+    server.signal_close();
+
+    Scheduler::enter([port, &payload] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        // Receive payload
+        std::array<uint8_t, k_buf_sz> recv_buf{};
+        for (std::span<uint8_t> view{recv_buf}; !view.empty();) {
+            Status<std::span<uint8_t>, int> recv = socket.recv_some(view);
+            AXLE_TEST_ASSERT_OK(recv);
+            const std::span<uint8_t> recv_view = recv.ok();
+            if (recv_view.empty()) {
+                break;
+            }
+
+            view = view.subspan(recv_view.size());
+        }
+        ASSERT_EQ(payload, recv_buf);
+
+        // Receive EOF
+        const std::span<uint8_t> buf_view{recv_buf};
+        Status<std::span<uint8_t>, int> recv = socket.recv_some(buf_view);
+        AXLE_TEST_ASSERT_OK(recv);
+        ASSERT_TRUE(recv.ok().empty());
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+TEST(AsyncClientSocketTest, ServerBlockingSendAndClose) {
+    const int port = test_port();
+    std::array<uint8_t, k_buf_sz> payload{};
+    rnd_buf(payload);
+    SendOnSignalServer server{port, payload};
+    server.start();
+
+    Scheduler::enter([port, &server, &payload] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        // Runs after the first call to `recv_some` below blocks.
+        Scheduler::schedule([&server] {
+            server.signal_send();
+            server.signal_close();
+        });
+
+        // Receive payload
+        std::array<uint8_t, k_buf_sz> recv_buf{};
+        for (std::span<uint8_t> view{recv_buf}; !view.empty();) {
+            Status<std::span<uint8_t>, int> recv = socket.recv_some(view);
+            AXLE_TEST_ASSERT_OK(recv);
+            const std::span<uint8_t> recv_view = recv.ok();
+            if (recv_view.empty()) {
+                break;
+            }
+
+            view = view.subspan(recv_view.size());
+        }
+        ASSERT_EQ(payload, recv_buf);
+
+        // Receive EOF
+        const std::span<uint8_t> buf_view{recv_buf};
+        Status<std::span<uint8_t>, int> recv = socket.recv_some(buf_view);
+        AXLE_TEST_ASSERT_OK(recv);
+        ASSERT_TRUE(recv.ok().empty());
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+TEST(AsyncClientSocketTest, ServerBlockingSendThenClose) {
+    const int port = test_port();
+    std::array<uint8_t, k_buf_sz> payload{};
+    SendOnSignalServer server{port, payload};
+    server.start();
+
+    Scheduler::enter([port, &server, &payload] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        // Runs after the call to recv_some below blocks
+        Scheduler::schedule([&server] { server.signal_send(); });
+
+        // Receive payload
+        std::array<uint8_t, k_buf_sz> recv_buf{};
+        for (std::span<uint8_t> view{recv_buf}; !view.empty();) {
+            Status<std::span<uint8_t>, int> recv = socket.recv_some(view);
+            AXLE_TEST_ASSERT_OK(recv);
+            const std::span<uint8_t> recv_view = recv.ok();
+            if (recv_view.empty()) {
+                break;
+            }
+
+            view = view.subspan(recv_view.size());
+        }
+        ASSERT_EQ(payload, recv_buf);
+
+        // Runs after the call to recv_some below blocks
+        Scheduler::schedule([&server] { server.signal_close(); });
+
+        // Receive EOF
+        const std::span<uint8_t> buf_view{recv_buf};
+        Status<std::span<uint8_t>, int> recv = socket.recv_some(buf_view);
+        AXLE_TEST_ASSERT_OK(recv);
+        ASSERT_TRUE(recv.ok().empty());
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+// TODO (whalbawi): Flaky under ASan
+TEST(AsyncClientSocketTest, DISABLED_ConnectSendClose) {
+    const int port = test_port();
+    ResetOnSignalServer server{port};
+
+    server.start();
+    Scheduler::enter([&server, port] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        Status<size_t, int> send_buf = socket::get_sndbuf_sz(socket.get_fd());
+        AXLE_TEST_ASSERT_OK(send_buf);
+        const size_t send_buf_sz = send_buf.ok();
+
+        Status<size_t, int> recv_buf = socket::get_rcvbuf_sz(socket.get_fd());
+        AXLE_TEST_ASSERT_OK(recv_buf);
+        const size_t recv_buf_sz = recv_buf.ok();
+
+        Scheduler::schedule([&server] { server.signal_close(); }, "close_server");
+        std::vector<uint8_t> buf((send_buf_sz + recv_buf_sz) * 2, 0);
+        rnd_buf(buf);
+        Status<None, int> send = socket.send_all(buf);
+        ASSERT_TRUE(send.is_err());
+        const int err = send.err();
+        // EPIPE if the server side recv buffer is empty. ECONNRESET, otherwise.
+        // We cannot control which is which but the net result is the same.
+        ASSERT_TRUE((err == ECONNRESET) || (err == EPIPE)) << err;
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+TEST(AsyncSocketTest, NoStaleReadRegistration) {
+    const uint64_t timeout_ns = 2e8;
+    const int port = test_port();
+    std::array<uint8_t, k_buf_sz> payload{};
+
+    SendOnSignalServer server{port, payload};
+    server.start();
+
+    Scheduler::enter([&] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        server.signal_send();
+
+        // Receive payload
+        std::array<uint8_t, k_buf_sz> recv_buf{};
+        for (std::span<uint8_t> view{recv_buf}; !view.empty();) {
+            Status<std::span<uint8_t>, int> recv = socket.recv_some(view);
+            AXLE_TEST_ASSERT_OK(recv);
+            const std::span<uint8_t> recv_view = recv.ok();
+            if (recv_view.empty()) {
+                break;
+            }
+
+            view = view.subspan(recv_view.size());
+        }
+        ASSERT_EQ(payload, recv_buf);
+
+        bool timer_fired = false;
+        auto ev = Scheduler::get_event_loop();
+        Status timer = ev->register_timer(
+            timeout_ns, false, [&timer_fired, fiber = Scheduler::current_fiber()](auto) {
+                timer_fired = true;
+                Scheduler::resume(fiber);
+            });
+        AXLE_TEST_ASSERT_OK(timer);
+
+        server.signal_close();
+        Scheduler::yield();
+
+        // In case of a stale registration, the next line will be executed before the timer fires.
+        ASSERT_TRUE(timer_fired);
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+TEST(AsyncSocketTest, NoStaleWriteRegistration) {
+    const uint64_t timeout_ns = 2e8;
+    Status fd_status = socket::create_tcp();
+    AXLE_TEST_ASSERT_OK(fd_status);
+
+    const int fd = fd_status.ok();
+
+    // Send a large buffer so that `send_all` blocks
+    Status<size_t, int> sndbuf_sz_status = socket::get_sndbuf_sz(fd);
+    AXLE_TEST_ASSERT_OK(sndbuf_sz_status);
+    const size_t send_buf_sz = sndbuf_sz_status.ok();
+
+    Status<size_t, int> rcvbuf_sz_status = socket::get_rcvbuf_sz(fd);
+    AXLE_TEST_ASSERT_OK(rcvbuf_sz_status);
+    const size_t recv_buf_sz = rcvbuf_sz_status.ok();
+
+    const size_t buf_sz = 2 * (recv_buf_sz + send_buf_sz);
+
+    const int port = test_port();
+    std::vector<uint8_t> payload;
+    payload.resize(buf_sz);
+
+    RecvOnSignalServer server{port, payload};
+    server.start();
+
+    Scheduler::enter([&] {
+        AsyncClientSocket socket{};
+        AXLE_TEST_ASSERT_OK(socket.connect("127.0.0.1", port));
+
+        Scheduler::schedule([&server] { server.signal_recv(); });
+
+        std::vector<uint8_t> buf;
+        buf.resize(buf_sz);
+        Status send = socket.send_all(buf);
+        AXLE_TEST_ASSERT_OK(send);
+        ASSERT_EQ(payload, buf);
+
+        bool timer_fired = false;
+        auto ev = Scheduler::get_event_loop();
+        Status timer = ev->register_timer(
+            timeout_ns, false, [&timer_fired, fiber = Scheduler::current_fiber()](auto) {
+                timer_fired = true;
+                Scheduler::resume(fiber);
+            });
+        AXLE_TEST_ASSERT_OK(timer);
+
+        server.signal_close();
+        Scheduler::yield();
+
+        // In case of a stale registration, the next line will be executed before the timer fires.
+        ASSERT_TRUE(timer_fired);
+
+        AXLE_TEST_ASSERT_OK(socket.close());
+        Scheduler::shutdown();
+    });
+    server.join();
+}
+
+} // namespace axle
+
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <algorithm>
+#include <random>
+#include <span>
+
+#ifndef AXLE_TEST_RNG_SEED
+#define AXLE_TEST_RNG_SEED 42
+#endif
+
+#define AXLE_TEST_ASSERT_OK(status)                                                                \
+    {                                                                                              \
+        auto&& status__ = (status);                                                                \
+        if (status__.is_err()) {                                                                   \
+            FAIL() << #status << " is not OK - error=" << status__.err();                          \
+        }                                                                                          \
+    }
+
+#define AXLE_TEST_ASSERT_ERR(status, errval)                                                       \
+    {                                                                                              \
+        auto&& status__ = (status);                                                                \
+        if (status__.is_ok()) {                                                                    \
+            FAIL() << #status << " is not ERR";                                                    \
+        }                                                                                          \
+        ASSERT_EQ((errval), status.err());                                                         \
+    }
+
+template <typename C>
+concept Iterable = requires(C& c) {
+    std::begin(c);
+    std::end(c);
+};
+
+template <Iterable C>
+inline void rnd_buf(C& c) {
+    using T = C::value_type;
+    constexpr T seed = AXLE_TEST_RNG_SEED;
+
+    static thread_local std::mt19937 rng{seed};
+    std::uniform_int_distribution<T> dist;
+    std::generate(std::begin(c), std::end(c), [&] { return dist(rng); });
+}


### PR DESCRIPTION
In addition to adding tests for `AsyncSocket` and derived classes, address an fd registration staleness bug that results in the callback firing and perhaps resuming the fiber from the wrong location. Implements `AsyncClientSocket::connect` which was missing for some reason.

Also, cleans up some stale NOLINT directives that seem to be OK now