### PR TITLE
gate: axle's first synchronization primitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set(AXLE_SRC_LIST
     ${AXLE_SRC_DIR}/axle.cpp
     ${AXLE_SRC_DIR}/event.cpp
     ${AXLE_SRC_DIR}/fiber.cpp
+    ${AXLE_SRC_DIR}/gate.cpp
     ${AXLE_SRC_DIR}/scheduler.cpp
     ${AXLE_SRC_DIR}/socket.cpp
     ${AXLE_SRC_DIR}/fiber_arm64.cpp
@@ -111,6 +112,7 @@ set(AXLE_TEST_LIST
     ${AXLE_TEST_DIR}/axle_test.cpp
     ${AXLE_TEST_DIR}/event_test.cpp
     ${AXLE_TEST_DIR}/fiber_test.cpp
+    ${AXLE_TEST_DIR}/gate_test.cpp
     ${AXLE_TEST_DIR}/scheduler_test.cpp
     ${AXLE_TEST_DIR}/status_test.cpp
 )

--- a/include/axle/async_socket.h
+++ b/include/axle/async_socket.h
@@ -1,5 +1,8 @@
+#include <memory>
+#include <span>
+
 #include "axle/event.h"
-#include "axle/socket.h"
+#include "axle/gate.h"
 
 namespace axle {
 
@@ -7,9 +10,9 @@ class AsyncSocket {
   public:
     AsyncSocket();
     explicit AsyncSocket(int fd);
-    AsyncSocket(AsyncSocket&& other) noexcept;
     virtual ~AsyncSocket();
 
+    AsyncSocket(AsyncSocket&& other) noexcept;
     AsyncSocket(const AsyncSocket&) = delete;
     AsyncSocket& operator=(const AsyncSocket&) = delete;
     AsyncSocket& operator=(AsyncSocket&&) = delete;
@@ -22,6 +25,7 @@ class AsyncSocket {
 
   protected:
     std::shared_ptr<EventLoop> event_loop_; // NOLINT(misc-non-private-member-variables-in-classes)
+    Gate gate_;                             // NOLINT(misc-non-private-member-variables-in-classes)
 
   private:
     int fd_;

--- a/include/axle/gate.h
+++ b/include/axle/gate.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <cstddef>
+
+#include <memory>
+
+#include "axle/status.h"
+
+namespace axle {
+
+class Fiber;
+
+class Gate {
+  public:
+    Gate();
+    void post() const;
+
+    Status<None, None> wait() const;
+
+  private:
+    struct State {
+        std::shared_ptr<Fiber> waiting_fiber_;
+        bool posted_{};
+    };
+    std::shared_ptr<State> state_;
+};
+
+} // namespace axle

--- a/include/axle/status.h
+++ b/include/axle/status.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <concepts>
+#include <string>
 #include <utility>
 #include <variant>
 
@@ -52,6 +53,12 @@ class Status {
 
     E err()
         requires(!std::same_as<E, None>);
+
+    std::string err()
+        requires(std::same_as<E, None>);
+
+    std::string ok()
+        requires(std::same_as<T, None>);
 
   private:
     Status() = delete;
@@ -103,6 +110,21 @@ E Status<T, E>::err()
     requires(!std::same_as<E, None>)
 {
     return std::move(std::get<1>(state_));
+}
+
+template <typename T, typename E>
+std::string Status<T, E>::ok()
+    requires(std::same_as<T, None>)
+{
+
+    return "(nil)";
+}
+
+template <typename T, typename E>
+std::string Status<T, E>::err()
+    requires(std::same_as<E, None>)
+{
+    return "(nil)";
 }
 
 } // namespace axle

--- a/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
+++ b/sanitizers/asan/asan_leak_supp_darwin_arm64.txt
@@ -6,3 +6,4 @@ leak:dyld4::APIs::setErrorString
 # Github is unable to pick up the previous suppressions. The following temporary work-arounds.
 leak:*SchedulerTest_RunTasks_Test
 leak:std::runtime_error::~runtime_error
+leak:std::logic_error::~logic_error

--- a/src/async_socket.cpp
+++ b/src/async_socket.cpp
@@ -3,14 +3,18 @@
 #include <cerrno>
 #include <cstdint>
 
+#include <memory>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
+#include "common.h"
+#include "debug.h"
 #include "fiber.h" // IWYU pragma: keep
 #include "socket_common.h"
 #include "axle/event.h"
+#include "axle/gate.h"
 #include "axle/scheduler.h"
 #include "axle/status.h"
 
@@ -28,25 +32,39 @@ AsyncSocket::AsyncSocket()
 
 AsyncSocket::AsyncSocket(int fd) : event_loop_(Scheduler::get_event_loop()), fd_(fd) {
     if (socket::set_non_blocking(fd_).is_err()) {
-        (void)close();
+        const Status close_st = close();
+        AXLE_ASSERT(close_st.is_ok());
 
         throw std::runtime_error("failed to put socket in non-blocking mode");
     }
 
     if (socket::set_opt_nosigpipe(fd_).is_err()) {
-        (void)close();
+        const Status close_st = close();
+        AXLE_ASSERT(close_st.is_ok());
 
         throw std::runtime_error("could not set SO_NOSIGPIPE for socket");
+    }
+
+    const Status<None, int> ev_status =
+        event_loop_->register_fd_read(get_fd(), [gate = gate_](Status<int64_t, uint32_t> status) {
+            // TODO(whalbawi, 310326): Handle properly
+            AXLE_UNUSED(status);
+            gate.post();
+        });
+
+    if (ev_status.is_err()) {
+        throw std::runtime_error("could not register fd with event loop for read readiness");
     }
 }
 
 AsyncSocket::AsyncSocket(AsyncSocket&& other) noexcept
-    : event_loop_(std::move(other.event_loop_)), fd_(other.fd_) {
+    : event_loop_(std::move(other.event_loop_)), gate_(std::move(other.gate_)), fd_(other.fd_) {
     other.fd_ = -1;
 }
 
 AsyncSocket::~AsyncSocket() {
-    (void)close();
+    const Status close_st = close();
+    AXLE_ASSERT(close_st.is_ok());
 }
 
 Status<None, int> AsyncSocket::send_all(std::span<const uint8_t> buf_view) const {
@@ -60,18 +78,19 @@ Status<None, int> AsyncSocket::send_all(std::span<const uint8_t> buf_view) const
         const int err = send_status.err();
         switch (err) {
         case EWOULDBLOCK: {
-            Status<None, int> ev_status = event_loop_->register_fd_write(
-                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t> status) {
-                    (void)status;
-                    Scheduler::resume(fiber);
+            Gate gate{};
+            Status<None, int> ev_status =
+                event_loop_->register_fd_write(get_fd(), [&gate](Status<int64_t, uint32_t> status) {
+                    AXLE_ASSERT(status.is_ok());
+                    gate.post();
                 });
             if (ev_status.is_err()) {
                 return Err(ev_status.err());
             }
-            Scheduler::yield();
-            (void)event_loop_->remove_fd_write(get_fd());
-            if (Scheduler::current_fiber()->interrupted()) {
-                (void)event_loop_->remove_fd_write(get_fd());
+            const Status wait_st = gate.wait();
+            const Status remove_st = event_loop_->remove_fd_write(get_fd());
+            AXLE_ASSERT(remove_st.is_ok());
+            if (wait_st.is_err()) {
                 return Err(EINTR);
             }
             continue;
@@ -94,18 +113,10 @@ Status<std::span<uint8_t>, int> AsyncSocket::recv_some(std::span<uint8_t> buf_vi
         const int err = recv_status.err();
         switch (err) {
         case EWOULDBLOCK: {
-            Status<None, int> ev_status = event_loop_->register_fd_read(
-                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t> status) {
-                    (void)status;
-                    Scheduler::resume(fiber);
-                });
-            if (ev_status.is_err()) {
-                return Err(ev_status.err());
-            }
-            Scheduler::yield();
-            (void)event_loop_->remove_fd_read(get_fd());
-            if (Scheduler::current_fiber()->interrupted()) {
-                (void)event_loop_->remove_fd_read(get_fd());
+            const Status wait_st = gate_.wait();
+            if (wait_st.is_err()) {
+                const Status rem = event_loop_->remove_fd_read(get_fd());
+                AXLE_ASSERT(rem.is_ok());
                 return Err(EINTR);
             }
             continue;
@@ -118,8 +129,10 @@ Status<std::span<uint8_t>, int> AsyncSocket::recv_some(std::span<uint8_t> buf_vi
 
 Status<None, int> AsyncSocket::close() {
     if (event_loop_) {
-        (void)event_loop_->remove_fd_write(get_fd());
-        (void)event_loop_->remove_fd_read(get_fd());
+        const Status rem_write_st = event_loop_->remove_fd_write(get_fd());
+        AXLE_UNUSED(rem_write_st.is_ok());
+        const Status rem_read_st = event_loop_->remove_fd_read(get_fd());
+        AXLE_UNUSED(rem_read_st.is_ok());
     }
 
     Status<None, int> close_status = socket::close(fd_);
@@ -146,18 +159,20 @@ Status<None, int> AsyncClientSocket::connect(const std::string& address, int por
         const int err = connect_status.err();
         switch (err) {
         case EINPROGRESS: {
-            Status<None, int> ev_status = event_loop_->register_fd_write(
-                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t> status) {
-                    (void)status;
-                    Scheduler::resume(fiber);
+            const Gate gate{};
+            Status<None, int> ev_status =
+                event_loop_->register_fd_write(get_fd(), [gate](Status<int64_t, uint32_t> status) {
+                    AXLE_UNUSED(status.is_ok());
+                    gate.post();
                 });
             if (ev_status.is_err()) {
                 return Err(ev_status.err());
             }
 
-            Scheduler::yield();
-            (void)event_loop_->remove_fd_write(get_fd());
-            if (Scheduler::current_fiber()->interrupted()) {
+            const Status wait_st = gate.wait();
+            const Status rem_st = event_loop_->remove_fd_write(get_fd());
+            AXLE_ASSERT(rem_st.is_ok());
+            if (wait_st.is_err()) {
                 return Err(EINTR);
             }
 
@@ -200,17 +215,10 @@ Status<AsyncSocket, int> AsyncServerSocket::accept() const {
         const int err = accept_status.err();
         switch (err) {
         case EWOULDBLOCK: {
-            Status<None, int> ev_status = event_loop_->register_fd_read(
-                get_fd(), [fiber = Scheduler::current_fiber()](Status<int64_t, uint32_t> status) {
-                    (void)status;
-                    Scheduler::resume(fiber);
-                });
-            if (ev_status.is_err()) {
-                return Err(ev_status.err());
-            }
-            Scheduler::yield();
-            if (Scheduler::current_fiber()->interrupted()) {
-                (void)event_loop_->remove_fd_read(get_fd());
+            const Status wait_st = gate_.wait();
+            if (wait_st.is_err()) {
+                const Status rem_st = event_loop_->remove_fd_read(get_fd());
+                AXLE_ASSERT(rem_st.is_ok());
                 return Err(EINTR);
             }
             continue;

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define AXLE_UNUSED(expr) (void)(expr)

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <cassert>
+
 #include <concepts>
 #include <format>
 #include <memory>
 #include <type_traits>
 
+#include "common.h"
 #include "fiber.h"
 
 #if !defined(AXLE_DEBUG_ENABLED)
@@ -71,7 +73,7 @@ void log_dbg(std::format_string<Args...> fmt, Args&&... args) {
 
 #define AXLE_ASSERT(cond)                                                                          \
     {                                                                                              \
-        (void)(cond);                                                                              \
+        AXLE_UNUSED(cond);                                                                         \
         assert(cond);                                                                              \
     }
 

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -1,0 +1,47 @@
+#include "axle/gate.h"
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include "debug.h"
+#include "axle/scheduler.h"
+#include "axle/status.h"
+
+namespace axle {
+
+Gate::Gate() : state_(std::make_shared<State>()) {}
+
+void Gate::post() const {
+    if (state_->posted_) {
+        return;
+    }
+
+    state_->posted_ = true;
+    if (state_->waiting_fiber_) {
+        Scheduler::resume(std::exchange(state_->waiting_fiber_, nullptr));
+    }
+}
+
+Status<None, None> Gate::wait() const {
+    if (state_->waiting_fiber_) {
+        throw std::logic_error{"Gate already waited on"};
+    }
+
+    if (state_->posted_) {
+        state_->posted_ = false;
+        return Ok();
+    }
+
+    state_->waiting_fiber_ = Scheduler::current_fiber();
+    Scheduler::yield();
+    if (Scheduler::current_fiber()->interrupted()) {
+        return Err();
+    }
+    AXLE_ASSERT(state_->waiting_fiber_ == nullptr);
+
+    state_->posted_ = false;
+    return Ok();
+}
+
+} // namespace axle

--- a/src/poller_bsd.cpp
+++ b/src/poller_bsd.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "common.h"
 #include "poller_common.h"
 
 namespace axle {
@@ -69,24 +70,24 @@ std::vector<PollOutcome> Poller::poll() const {
         const struct kevent& ev = evs.at(i);
         switch (ev.filter) {
         case EVFILT_USER: {
-            (void)outcomes.emplace_back(ev.ident, PollEvent::USER, PollState::OK);
+            AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::USER, PollState::OK));
             break;
         }
 
         case EVFILT_READ: {
             const PollState state = (ev.flags & EV_ERROR) != 0 ? PollState::ERR : PollState::OK;
-            (void)outcomes.emplace_back(ev.ident, PollEvent::FD_READ, state);
+            AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::FD_READ, state));
             if ((ev.flags & EV_EOF) != 0) {
-                (void)outcomes.emplace_back(ev.ident, PollEvent::FD_EOF, state);
+                AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::FD_EOF, state));
             }
             break;
         }
 
         case EVFILT_WRITE: {
             const PollState state = (ev.flags & EV_ERROR) != 0 ? PollState::ERR : PollState::OK;
-            (void)outcomes.emplace_back(ev.ident, PollEvent::FD_WRITE, state);
+            AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::FD_WRITE, state));
             if ((ev.flags & EV_EOF) != 0) {
-                (void)outcomes.emplace_back(ev.ident, PollEvent::FD_EOF, state);
+                AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::FD_EOF, state));
             }
             break;
         }
@@ -94,13 +95,13 @@ std::vector<PollOutcome> Poller::poll() const {
         case EVFILT_TIMER: {
             // TODO (whalbawi): Confirm what happens when a timer fails and how errors are reported.
             const PollState state = (ev.flags & EV_ERROR) != 0 ? PollState::ERR : PollState::OK;
-            (void)outcomes.emplace_back(ev.ident, PollEvent::TIMER, state);
+            AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::TIMER, state));
             break;
         }
 
         case EVFILT_SIGNAL: {
             const PollState state = (ev.flags & EV_ERROR) != 0 ? PollState::ERR : PollState::OK;
-            (void)outcomes.emplace_back(ev.ident, PollEvent::SIGNAL, state);
+            AXLE_UNUSED(outcomes.emplace_back(ev.ident, PollEvent::SIGNAL, state));
             break;
         }
 

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "common.h"
 #include "debug.h"
 #include "fiber.h"
 #include "axle/event.h"
@@ -41,7 +42,7 @@ void Scheduler::init() {
         const std::lock_guard<std::mutex> lk{k_schedulers_mtx};
         std::unique_ptr<Scheduler> scheduler(
             new Scheduler(std::make_shared<EventLoop>(), host_thread));
-        (void)k_schedulers.emplace(host_thread, std::move(scheduler));
+        AXLE_UNUSED(k_schedulers.emplace(host_thread, std::move(scheduler)));
         k_instance = k_schedulers.at(host_thread).get();
     }
 }
@@ -55,7 +56,7 @@ void Scheduler::fini() {
     {
         const std::lock_guard<std::mutex> lk{k_schedulers_mtx};
         k_instance->do_fini();
-        (void)k_schedulers.erase(k_instance->host_thread_);
+        AXLE_UNUSED(k_schedulers.erase(k_instance->host_thread_));
         k_instance = nullptr;
     }
 }
@@ -94,7 +95,7 @@ void Scheduler::yield() {
 
 void Scheduler::resume(std::shared_ptr<Fiber> fiber) {
     Scheduler::ensure_inited();
-    (void)k_instance->blocked_fibers_.erase(fiber);
+    AXLE_UNUSED(k_instance->blocked_fibers_.erase(fiber));
     k_instance->enqueue(std::move(fiber));
 }
 
@@ -135,7 +136,7 @@ void Scheduler::do_yield() {
         throw std::runtime_error("scheduler is not running");
     }
     log_dbg("YIELD  {}", Scheduler::current_fiber());
-    (void)blocked_fibers_.insert(current_fiber_);
+    AXLE_UNUSED(blocked_fibers_.insert(current_fiber_));
     switch_to(main_fiber_);
 }
 
@@ -172,7 +173,7 @@ void Scheduler::do_enter(std::function<void()> entry_point) {
         },
         "entry_point");
     Status<int, int> reg_status = event_loop_->register_signal(SIGINT, [&](auto status) {
-        (void)status;
+        AXLE_UNUSED(status);
         do_shutdown();
     });
 
@@ -186,7 +187,7 @@ void Scheduler::do_enter(std::function<void()> entry_point) {
     // remove the signal handler.
     Status<None, int> rem_status = event_loop_->remove_signal(shutdown_handler_id);
     if (rem_status.is_err()) {
-        (void)rem_status.err();
+        AXLE_UNUSED(rem_status.err());
     }
 }
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "common.h"
 #include "socket_common.h"
 #include "axle/status.h"
 
@@ -24,7 +25,7 @@ Socket::Socket()
 
 Socket::Socket(int fd) : fd_(fd) {
     if (socket::set_opt_nosigpipe(fd_).is_err()) {
-        (void)close();
+        AXLE_UNUSED(close());
 
         throw std::runtime_error("could not set SO_NOSIGPIPE for socket");
     }
@@ -35,7 +36,7 @@ Socket::Socket(Socket&& other) noexcept : fd_(other.fd_) {
 }
 
 Socket::~Socket() {
-    (void)close();
+    AXLE_UNUSED(close());
 }
 
 Status<None, int> Socket::set_non_blocking() const {

--- a/src/socket_common.h
+++ b/src/socket_common.h
@@ -13,6 +13,7 @@
 #include <span>
 #include <string>
 
+#include "common.h"
 #include "axle/status.h"
 
 #ifndef MSG_NOSIGNAL
@@ -120,7 +121,7 @@ inline Status<None, int> set_opt_nosigpipe(const int fd) {
 #ifdef AXLE_USE_NOSIGPIPE
     return detail::do_setsockopt(fd, SO_NOSIGPIPE);
 #else
-    (void)fd;
+    AXLE_UNUSED(fd);
     return Ok();
 #endif // AXLE_USE_NOSIGPIPE
 }
@@ -146,7 +147,7 @@ inline Status<std::span<uint8_t>, int> recv(const int fd, const std::span<uint8_
     const ssize_t len = ::read(fd, buf.data(), buf.size());
     if (len == -1) {
         const int err = errno;
-        perror("read");
+        // perror("read");
 
         return Err(err);
     }
@@ -178,7 +179,7 @@ inline Status<int, int> accept(const int fd) {
     const int peer_fd = ::accept(fd, nullptr, nullptr);
     if (peer_fd == -1) {
         const int err = errno;
-        perror("accept");
+        // perror("accept");
 
         return Err(err);
     }

--- a/test/async_socket_test.cpp
+++ b/test/async_socket_test.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "socket_common.h"
+#include "axle/gate.h"
 #include "axle/scheduler.h"
 #include "axle/socket.h"
 #include "axle/status.h"
@@ -581,15 +582,15 @@ TEST(AsyncSocketTest, NoStaleReadRegistration) {
 
         bool timer_fired = false;
         auto ev = Scheduler::get_event_loop();
-        Status timer = ev->register_timer(
-            timeout_ns, false, [&timer_fired, fiber = Scheduler::current_fiber()](auto) {
-                timer_fired = true;
-                Scheduler::resume(fiber);
-            });
+        const Gate gate{};
+        Status timer = ev->register_timer(timeout_ns, false, [&timer_fired, gate](auto) {
+            timer_fired = true;
+            gate.post();
+        });
         AXLE_TEST_ASSERT_OK(timer);
 
         server.signal_close();
-        Scheduler::yield();
+        AXLE_TEST_ASSERT_OK(gate.wait());
 
         // In case of a stale registration, the next line will be executed before the timer fires.
         ASSERT_TRUE(timer_fired);
@@ -639,15 +640,15 @@ TEST(AsyncSocketTest, NoStaleWriteRegistration) {
 
         bool timer_fired = false;
         auto ev = Scheduler::get_event_loop();
-        Status timer = ev->register_timer(
-            timeout_ns, false, [&timer_fired, fiber = Scheduler::current_fiber()](auto) {
-                timer_fired = true;
-                Scheduler::resume(fiber);
-            });
+        Gate gate{};
+        Status timer = ev->register_timer(timeout_ns, false, [&timer_fired, &gate](auto) {
+            timer_fired = true;
+            gate.post();
+        });
         AXLE_TEST_ASSERT_OK(timer);
 
         server.signal_close();
-        Scheduler::yield();
+        AXLE_TEST_ASSERT_OK(gate.wait());
 
         // In case of a stale registration, the next line will be executed before the timer fires.
         ASSERT_TRUE(timer_fired);

--- a/test/event_test.cpp
+++ b/test/event_test.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 #include <utility>
 
+#include "common.h"
 #include "axle/socket.h"
 #include "axle/status.h"
 
@@ -248,7 +249,7 @@ class IncrementServer {
     explicit IncrementServer(int port) : port_(port), socket_{ServerSocket()}, running_{false} {}
 
     ~IncrementServer() {
-        (void)socket_.close();
+        AXLE_UNUSED(socket_.close());
     }
 
     void start() {
@@ -269,14 +270,14 @@ class IncrementServer {
                 std::span<uint8_t> buf_view{buf_};
                 Status<std::span<uint8_t>, int> recv_some_res = peer_socket.recv_some(buf_view);
                 if (recv_some_res.is_err()) {
-                    (void)peer_socket.close();
+                    AXLE_UNUSED(peer_socket.close());
                     break;
                 }
 
                 buf_view = recv_some_res.ok();
 
                 if (buf_view.empty()) {
-                    (void)peer_socket.close();
+                    AXLE_UNUSED(peer_socket.close());
                     break;
                 }
 
@@ -285,7 +286,7 @@ class IncrementServer {
                 }
 
                 if (peer_socket.send_all(buf_view).is_err()) {
-                    (void)peer_socket.close();
+                    AXLE_UNUSED(peer_socket.close());
                     break;
                 }
             }
@@ -346,7 +347,7 @@ class Request {
     }
 
     void end() {
-        (void)socket_.close();
+        AXLE_UNUSED(socket_.close());
     }
 
     State get_state() {

--- a/test/gate_test.cpp
+++ b/test/gate_test.cpp
@@ -1,0 +1,262 @@
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+#include "axle/gate.h"
+
+#include <functional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "common.h"
+#include "axle/scheduler.h"
+
+#include "gtest/gtest.h"
+
+#include "test_common.h"
+
+namespace axle {
+namespace {
+
+TEST(GateTest, Works) {
+    bool gate_passed = false;
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+
+        Scheduler::schedule([gate] { gate.post(); });
+
+        AXLE_TEST_ASSERT_OK(gate.wait());
+        gate_passed = true;
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_TRUE(gate_passed);
+}
+
+TEST(GateTest, DoubleWait) {
+    int exception_cnt = 0;
+    int tasks_run_cnt = 0;
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+        const Gate task_a_start{};
+        const Gate task_b_start{};
+        const Gate task_a_done{};
+        const Gate task_b_done{};
+
+        auto task = [&gate, &tasks_run_cnt, &exception_cnt](const Gate& task_start,
+                                                            const Gate& task_done) {
+            task_start.post();
+            tasks_run_cnt++;
+            if (tasks_run_cnt == 1) {
+                AXLE_TEST_ASSERT_OK(gate.wait());
+            } else {
+                ASSERT_THROW(AXLE_UNUSED(gate.wait()), std::logic_error);
+                exception_cnt++;
+            }
+            task_done.post();
+        };
+        Scheduler::schedule([&] { task(task_a_start, task_a_done); });
+        Scheduler::schedule([&] { task(task_b_start, task_b_done); });
+
+        AXLE_TEST_ASSERT_OK(task_a_start.wait());
+        AXLE_TEST_ASSERT_OK(task_b_start.wait());
+        gate.post();
+        AXLE_TEST_ASSERT_OK(task_a_done.wait());
+        AXLE_TEST_ASSERT_OK(task_b_done.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_EQ(2, tasks_run_cnt);
+    ASSERT_EQ(1, exception_cnt);
+}
+
+TEST(GateTest, PostBeforeWait) {
+    bool gate_passed = false;
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+        const Gate task_done{};
+
+        Scheduler::schedule([&] {
+            AXLE_TEST_ASSERT_OK(gate.wait());
+            gate_passed = true;
+            task_done.post();
+        });
+
+        gate.post();
+        AXLE_TEST_ASSERT_OK(task_done.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_TRUE(gate_passed);
+}
+
+TEST(GateTest, DoublePostIsNoop) {
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+        const Gate task_done{};
+
+        gate.post();
+        gate.post();
+        AXLE_TEST_ASSERT_OK(gate.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+}
+
+TEST(GateTest, PostBeforeWaitSamefiber) {
+    bool gate_passed = false;
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+
+        gate.post();
+        AXLE_TEST_ASSERT_OK(gate.wait());
+        gate_passed = true;
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_TRUE(gate_passed);
+}
+
+TEST(GateTest, Reuse) {
+    int wait_cnt = 0;
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+        const Gate gate_1{};
+        const Gate gate_2{};
+
+        Scheduler::schedule([&] {
+            AXLE_TEST_ASSERT_OK(gate.wait());
+            wait_cnt++;
+            gate_1.post();
+
+            AXLE_TEST_ASSERT_OK(gate.wait());
+            wait_cnt++;
+            gate_2.post();
+        });
+
+        gate.post();
+        AXLE_TEST_ASSERT_OK(gate_1.wait());
+        gate.post();
+        AXLE_TEST_ASSERT_OK(gate_2.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_EQ(2, wait_cnt);
+}
+
+TEST(GateTest, ReusePostBeforeWait) {
+    int wait_cnt = 0;
+    std::function<void()> entry_point = [&] {
+        const Gate gate{};
+
+        gate.post();
+        AXLE_TEST_ASSERT_OK(gate.wait());
+        wait_cnt++;
+
+        gate.post();
+        AXLE_TEST_ASSERT_OK(gate.wait());
+        wait_cnt++;
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_EQ(2, wait_cnt);
+}
+
+TEST(GateTest, ChainedGates) {
+    std::vector<int> order;
+    std::function<void()> entry_point = [&] {
+        const Gate a{};
+        const Gate b{};
+        const Gate c{};
+        const Gate done{};
+
+        Scheduler::schedule([&] {
+            AXLE_TEST_ASSERT_OK(a.wait());
+            order.push_back(1);
+            b.post();
+        });
+        Scheduler::schedule([&] {
+            AXLE_TEST_ASSERT_OK(b.wait());
+            order.push_back(2);
+            c.post();
+        });
+        Scheduler::schedule([&] {
+            AXLE_TEST_ASSERT_OK(c.wait());
+            order.push_back(3);
+            done.post();
+        });
+
+        a.post();
+        AXLE_TEST_ASSERT_OK(done.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_EQ(3, order.size());
+    ASSERT_EQ(1, order[0]);
+    ASSERT_EQ(2, order[1]);
+    ASSERT_EQ(3, order[2]);
+}
+
+TEST(GateTest, MoveConstruct) {
+    bool gate_passed = false;
+    std::function<void()> entry_point = [&] {
+        Gate original{};
+        const Gate gate{std::move(original)};
+        const Gate task_done{};
+
+        Scheduler::schedule([&] {
+            gate.post();
+            task_done.post();
+        });
+
+        AXLE_TEST_ASSERT_OK(gate.wait());
+        gate_passed = true;
+        AXLE_TEST_ASSERT_OK(task_done.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_TRUE(gate_passed);
+}
+
+TEST(GateTest, WaitReturnsErrOnShutdown) {
+    const Gate init{};
+    const Gate gate{};
+    Scheduler::enter([&] {
+        Scheduler::schedule([&] {
+            init.post();
+            // Runs in the context of `fini` which interrupts the fiber.
+            AXLE_TEST_ASSERT_ERR(gate.wait(), "(nil)");
+        });
+        AXLE_TEST_ASSERT_OK(init.wait());
+    });
+}
+
+TEST(GateTest, PingPong) {
+    constexpr int rounds_cnt = 100;
+    int round_cnt = 0;
+    std::function<void()> entry_point = [&] {
+        const Gate ping{};
+        const Gate pong{};
+        const Gate done{};
+
+        Scheduler::schedule([&] {
+            for (int i = 0; i < rounds_cnt; i++) {
+                AXLE_TEST_ASSERT_OK(ping.wait());
+                round_cnt++;
+                pong.post();
+            }
+            done.post();
+        });
+
+        for (int i = 0; i < rounds_cnt; i++) {
+            ping.post();
+            AXLE_TEST_ASSERT_OK(pong.wait());
+        }
+        AXLE_TEST_ASSERT_OK(done.wait());
+    };
+
+    Scheduler::enter(std::move(entry_point));
+    ASSERT_EQ(rounds_cnt, round_cnt);
+}
+
+} // namespace
+} // namespace axle
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -22,7 +22,7 @@
         if (status__.is_ok()) {                                                                    \
             FAIL() << #status << " is not ERR";                                                    \
         }                                                                                          \
-        ASSERT_EQ((errval), status.err());                                                         \
+        ASSERT_EQ((errval), status__.err());                                                       \
     }
 
 template <typename C>


### PR DESCRIPTION
Coordinates fiber yield-resumption dance by providing a post-wait pair of methods that can be invoked in exactly that order, before being reused. No two fibers can wait on the same `Gate` at the same time, because we support waking up only one.