### PR TITLE
fiber: Include correct fiber header in fiber.cpp

### DIFF
--- a/src/fiber.cpp
+++ b/src/fiber.cpp
@@ -9,14 +9,14 @@
 #include <string>
 #include <utility>
 
-#include "fiber_arm64.h"
+#include "fiber_platform.h"
 #include "sanitizer.h"
+
+namespace axle {
 
 extern "C" {
 void axle_fiber_swap(FiberCtx* src, const FiberCtx* dst);
 }
-
-namespace axle {
 
 enum : uint8_t {
     FIBER_EXIT_CODE = 0x19,

--- a/src/fiber.h
+++ b/src/fiber.h
@@ -7,7 +7,7 @@
 #include <format>
 #include <functional>
 
-#include "fiber_arm64.h"
+#include "fiber_platform.h"
 #include "sanitizer.h"
 
 namespace axle {

--- a/src/fiber_arm64.cpp
+++ b/src/fiber_arm64.cpp
@@ -1,8 +1,8 @@
-#include "fiber_arm64.h"
-
 #include <cstdint>
 
 #include <span>
+
+#include "fiber_platform.h"
 
 namespace {
 

--- a/src/fiber_arm64.h
+++ b/src/fiber_arm64.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
-#include <span>
-
 #include "fiber_reg_off_arm64.h"
+
+namespace axle {
 
 struct FiberCtx {
     uintptr_t x0; // Holds source fiber
@@ -71,9 +72,5 @@ static_assert(offsetof(FiberCtx, d15) == AXLE_REG_OFF_ARM64_D15, "bad offset for
 static_assert(offsetof(FiberCtx,  sp) == AXLE_REG_OFF_ARM64_SP,  "bad offset for register sp");
 static_assert(offsetof(FiberCtx,  lr) == AXLE_REG_OFF_ARM64_LR,  "bad offset for register lr");
 // clang-format on
-
-namespace axle {
-
-void fiber_ctx_init(FiberCtx* ctx, std::span<uint8_t> stack, void (*target)(void*), void* arg);
 
 } // namespace axle

--- a/src/fiber_platform.h
+++ b/src/fiber_platform.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+#include <span>
+
+#if defined(__aarch64__)
+#include "fiber_arm64.h" // IWYU pragma: export -- axle::FiberCtx
+#elif defined(__x86_64__)
+#include "fiber_x64.h" // IWYU pragma: export -- axle::FiberCtx
+#endif                 // defined(__aarch64__)
+
+namespace axle {
+
+void fiber_ctx_init(FiberCtx* ctx, std::span<uint8_t> stack, void (*target)(void*), void* arg);
+
+} // namespace axle

--- a/src/fiber_x64.cpp
+++ b/src/fiber_x64.cpp
@@ -1,8 +1,8 @@
-#include "fiber_x64.h"
-
 #include <cstdint>
 
 #include <span>
+
+#include "fiber_platform.h"
 
 namespace {
 

--- a/src/fiber_x64.h
+++ b/src/fiber_x64.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
-#include <span>
-
 #include "fiber_reg_off_x64.h"
+
+namespace axle {
 
 struct FiberCtx {
     uintptr_t rbx;
@@ -32,9 +33,5 @@ static_assert(offsetof(FiberCtx, r14) == AXLE_REG_OFF_X64_R14, "bad offset for r
 static_assert(offsetof(FiberCtx, r15) == AXLE_REG_OFF_X64_R15, "bad offset for register r15");
 static_assert(offsetof(FiberCtx, rsp) == AXLE_REG_OFF_X64_RSP, "bad offset for register rsp");
 // clang-format on
-
-namespace axle {
-
-void fiber_ctx_init(FiberCtx* ctx, std::span<uint8_t> stack, void (*target)(void*), void* arg);
 
 } // namespace axle


### PR DESCRIPTION
We unconditionally included the arm-specific header, which happened to
work because its a larger struct than that on x64.

Introduces an export header for `axle::FiberCtx` and `fiber_ctx_init`.
Brings in everything into the `axle` namespace - the assembly function
`fiber_ctx_swap` gets hoisted into the global namespace since its
extern "C".
